### PR TITLE
Docs: update repo links to new URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for contributing!
 ## Installation
 
 ```bash
-git clone https://github.com/not-an-aardvark/eslint-plugin-prettier.git
+git clone https://github.com/prettier/eslint-plugin-prettier.git
 cd eslint-plugin-prettier
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-plugin-prettier [![Build Status](https://travis-ci.org/not-an-aardvark/eslint-plugin-prettier.svg?branch=master)](https://travis-ci.org/not-an-aardvark/eslint-plugin-prettier)
+# eslint-plugin-prettier [![Build Status](https://travis-ci.org/prettier/eslint-plugin-prettier.svg?branch=master)](https://travis-ci.org/prettier/eslint-plugin-prettier)
 
 Runs [prettier](https://github.com/jlongster/prettier) as an eslint rule
 


### PR DESCRIPTION
The travis sticker is currently broken:

![](https://i.gyazo.com/0f713fef10a717e10a459eae681ca68b.png)