### PR TITLE
Fix: Support ESLint <3.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ node_js:
   - '4'
   - '6'
   - '7'
+env:
+  - ESLINT_VERSION=latest
+  - ESLINT_VERSION=3.15.0
+before_script:
+  - if [[ $ESLINT_VERSION != "latest" ]]; then
+      yarn upgrade "eslint@$ESLINT_VERSION";
+    fi


### PR DESCRIPTION
Converting from a range/index to a location varies between ESLint versions. This PR covers versions all the way back to ESLint 3.9.0, and creates a test matrix of the various versions.

Context: Unfortunately, we have a project with ESLint 3.9.0 that I can't update right now without making a mess.