### PR TITLE
Chore: use eslint-plugin-self for linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,7 @@
 'use strict';
 
-// Register ourselves as a plugin to avoid `node_modules` trickery.
-const Plugins = require('eslint/lib/config/plugins');
-Plugins.define('prettier', require('.'));
-
 module.exports = {
-  plugins: ['node', 'eslint-plugin', 'prettier'],
+  plugins: ['node', 'eslint-plugin', 'self'],
   extends: [
     'not-an-aardvark/node',
     'plugin:node/recommended',
@@ -15,7 +11,7 @@ module.exports = {
   env: { mocha: true },
   root: true,
   rules: {
-    'prettier/prettier': ['error', { singleQuote: true }],
+    'self/prettier': ['error', { singleQuote: true }],
     'eslint-plugin/report-message-format': ['error', '^[^a-z].*\\.$']
   }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-config-prettier": "^1.3.0",
     "eslint-plugin-eslint-plugin": "^0.7.1",
     "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-self": "^1.0.1",
     "mocha": "^3.1.2",
     "moment": "^2.18.1",
     "prettier": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,6 +302,10 @@ eslint-plugin-node@^4.2.2:
     resolve "^1.1.7"
     semver "5.3.0"
 
+eslint-plugin-self@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-self/-/eslint-plugin-self-1.0.1.tgz#50efd8acf33a399670b7ce7c12b2fd9868b41e7e"
+
 eslint@^3.14.1:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"


### PR DESCRIPTION
This updates the ESLint config to use [`eslint-plugin-self`](https://github.com/not-an-aardvark/eslint-plugin-self) rather than monkeypatching ESLint's internals.