### PR TITLE
.eslintrc.json > .eslintrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save-dev prettier eslint-plugin-prettier
 
 **_`eslint-plugin-prettier` does not install Prettier or ESLint for you._** _You must install these yourself._
 
-Then, in your `.eslintrc`:
+Then, in your `.eslintrc.json`:
 
 ```json
 {


### PR DESCRIPTION
Figured it was worth specifying the .json extension because it takes higher precedence: https://eslint.org/docs/user-guide/configuring#configuration-file-formats

.eslintrc.json is what is recommended in prettier's README: https://github.com/prettier/prettier#eslint

.eslintrc is also slightly ambiguous given it can contain YAML