### PR TITLE
Guard against older prettier installation

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -337,7 +337,7 @@ module.exports = {
           }
         }
 
-        if (prettier) {
+        if (prettier && prettier.clearConfigCache) {
           prettier.clearConfigCache();
         }
 


### PR DESCRIPTION
We are on prettier 1.5.2 in a project, so it explodes with new version of the plugin.

```
Error while loading rule 'prettier/prettier': prettier.clearConfigCache is not a function
TypeError: Error while loading rule 'prettier/prettier': prettier.clearConfigCache is not a function
    at Object.create (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint-plugin-prettier/eslint-plugin-prettier.js:341:20)
    at Object.keys.forEach.ruleId (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/linter.js:957:44)
    at Array.forEach (<anonymous>)
    at Linter._verifyWithoutProcessors (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/linter.js:897:35)
    at preprocess.map.textBlock (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/linter.js:1019:35)
    at Array.map (<anonymous>)
    at Linter.verify (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/linter.js:1018:42)
    at Linter.verifyAndFix (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/linter.js:1100:29)
    at processText (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/cli-engine.js:173:32)
    at processFile (/Users/simbekkh/repos/process-exception-handlers/node_modules/eslint/lib/cli-engine.js:216:18)
```