### PR TITLE
Allow for use of forks of prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then, in your `.eslintrc.json`:
 
 * The first option:
   - Objects are passed directly to Prettier as [options](https://github.com/prettier/prettier#options). Example:
-    
+
     ```json
     "prettier/prettier": ["error", {"singleQuote": true, "parser": "flow"}]
     ```
@@ -78,6 +78,7 @@ Then, in your `.eslintrc.json`:
     }]
     ```
   NB: This option will merge and override any config set with `.prettierrc` files (for Prettier < 1.7.0, [config files are ignored](https://github.com/prettier/eslint-plugin-prettier/issues/46))
+
 
 * The second option:
 
@@ -106,6 +107,15 @@ Then, in your `.eslintrc.json`:
     ```
 
     _This option is useful if you're migrating a large codebase and already use pragmas like `@flow`._
+
+* The third option:
+
+  - Name of the NPM module to load instead of `prettier`. This is useful if you wish to use
+  a fork such as [prettier-miscellaneous](https://github.com/arijs/prettier-miscellaneous). Example:
+
+    ```json
+    "prettier/prettier": ["error", null, null, "prettier-miscellaneous"]
+    ```
 
 * The rule is autofixable -- if you run `eslint` with the `--fix` flag, your code will be formatted according to `prettier` style.
 

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -302,13 +302,23 @@ module.exports = {
             ]
           },
           // Pragma:
-          { type: 'string', pattern: '^@\\w+$' }
+          {
+            anyOf: [{ enum: [null] }, { type: 'string', pattern: '^@\\w+$' }]
+          },
+          // prettier fork module name
+          { type: 'string' }
         ]
       },
       create(context) {
         const pragma = context.options[1]
           ? context.options[1].slice(1) // Remove leading @
           : null;
+
+        if (!prettier) {
+          const prettierModule = context.options[2] || 'prettier';
+          // Prettier is expensive to load, so only load it if needed.
+          prettier = require(prettierModule);
+        }
 
         const sourceCode = context.getSourceCode();
         const source = sourceCode.text;
@@ -343,11 +353,6 @@ module.exports = {
 
         return {
           Program() {
-            if (!prettier) {
-              // Prettier is expensive to load, so only load it if needed.
-              prettier = require('prettier');
-            }
-
             const eslintPrettierOptions =
               context.options[0] === 'fb'
                 ? FB_PRETTIER_OPTIONS


### PR DESCRIPTION
This change allows for forks of prettier such as [prettier-miscellaneous](https://github.com/arijs/prettier-miscellaneous) to be used instead. Unlike #15 it doesn't use any special tricks to find the specified module, and thus avoids any associated problems.

`.eslintrc` syntax demo (e.g. if you want to use `prettier-miscellaneous`):

```js
...
    "prettier/prettier": [
      "error",
      {
        bracketSpacing: true,
        jsxBracketSameLine: true,
        printWidth: 80,
        ...
      },
      null,
      "prettier-miscellaneous"
    ]
  },
...
```