### PR TITLE
Add support for running prettier on script in Vue Single File Components

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -84,6 +84,20 @@ function getLocFromIndex(context, index) {
 }
 
 /**
+ * Gets the index of a given location in the source code for a given context.
+ * @param {RuleContext} context - The ESLint rule context.
+ * @param {Object} loc - An object containing numeric `line` and `column` keys.
+ * @returns {number} An index in the source code.
+ */
+function getIndexFromLoc(context, loc) {
+  const sourceCode = context.getSourceCode();
+  if (typeof sourceCode.getLocFromIndex === 'function') {
+    return sourceCode.getIndexFromLoc(loc);
+  }
+  throw new Error('Your ESLint version is not supported, please use >= 3.17.0');
+}
+
+/**
  * Converts invisible characters to a commonly recognizable visible form.
  * @param {string} str - The string with invisibles to convert.
  * @returns {string} The converted string.
@@ -349,7 +363,7 @@ module.exports = {
           : sourceCode.text;
         const startNodeLocation = sourceCode.ast.loc.start;
         const startIndex = isVue
-          ? sourceCode.getIndexFromLoc(startNodeLocation)
+          ? getIndexFromLoc(context, startNodeLocation)
           : 0;
 
         // Ensure vue script has trailing newline

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -11,6 +11,7 @@
 
 const diff = require('fast-diff');
 const docblock = require('jest-docblock');
+const path = require('path');
 
 // ------------------------------------------------------------------------------
 //  Constants
@@ -211,6 +212,37 @@ function generateDifferences(source, prettierSource) {
   }
 }
 
+/**
+ * Checks if current context is Vue file parsed with vue-eslint-parser
+ * @param {RuleContext} context - The ESLint rule context.
+ * @returns {boolean}
+ */
+function isVueContext(context) {
+  const STARTS_WITH_LT = /^\s*</;
+  const fileName = context.getFilename();
+  // We use defineTemplateBodyVisitor function provided by vue-eslint-parser
+  // to check if this parser is used
+  return (
+    (path.extname(fileName) === '.vue' ||
+      STARTS_WITH_LT.test(context.getSourceCode().text)) &&
+    typeof context.parserServices.defineTemplateBodyVisitor === 'function'
+  );
+}
+
+/**
+ * Detects line endings in given string
+ * @param {string} text - String for detecton
+ * @returns {string} - One line ending
+ */
+function guessLineEnding(text) {
+  // Based on https://github.com/prettier/prettier/blob/1.8.2/index.js#L17
+  const index = text.indexOf('\n');
+  if (index >= 0 && text.charAt(index - 1) === '\r') {
+    return '\r\n';
+  }
+  return '\n';
+}
+
 // ------------------------------------------------------------------------------
 //  Rule Definition
 // ------------------------------------------------------------------------------
@@ -310,8 +342,20 @@ module.exports = {
           ? context.options[1].slice(1) // Remove leading @
           : null;
 
+        const isVue = isVueContext(context);
         const sourceCode = context.getSourceCode();
-        const source = sourceCode.text;
+        let source = isVue
+          ? sourceCode.getText(sourceCode.ast)
+          : sourceCode.text;
+        const startNodeLocation = sourceCode.ast.loc.start;
+        const startIndex = isVue
+          ? sourceCode.getIndexFromLoc(startNodeLocation)
+          : 0;
+
+        // Ensure vue script has trailing newline
+        if (isVue && source.length && source.substr(-1) !== '\n') {
+          source += guessLineEnding(source);
+        }
 
         // The pragma is only valid if it is found in a block comment at the very
         // start of the file.
@@ -325,7 +369,9 @@ module.exports = {
             !(
               firstComment &&
               firstComment.type === 'Block' &&
-              firstComment.loc.start.line === (hasShebang ? 2 : 1) &&
+              (firstComment.loc.start.line === (hasShebang ? 2 : 1) ||
+                (isVue &&
+                  firstComment.loc.start.line < startNodeLocation.line)) &&
               firstComment.loc.start.column === 0
             )
           ) {
@@ -371,21 +417,21 @@ module.exports = {
                   case OPERATION_INSERT:
                     reportInsert(
                       context,
-                      difference.offset,
+                      startIndex + difference.offset,
                       difference.insertText
                     );
                     break;
                   case OPERATION_DELETE:
                     reportDelete(
                       context,
-                      difference.offset,
+                      startIndex + difference.offset,
                       difference.deleteText
                     );
                     break;
                   case OPERATION_REPLACE:
                     reportReplace(
                       context,
-                      difference.offset,
+                      startIndex + difference.offset,
                       difference.deleteText,
                       difference.insertText
                     );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "mocha": "^3.1.2",
     "moment": "^2.18.1",
     "prettier": "^1.6.1",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "vue-eslint-parser": "^2.0.1-beta.2"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/invalid/vue-01.txt
+++ b/test/invalid/vue-01.txt
@@ -1,0 +1,16 @@
+CODE:
+a();;;;;;
+
+OUTPUT:
+a();
+
+OPTIONS:
+[]
+
+ERRORS:
+[
+  {
+    message: 'Delete `;;;;;`',
+    line: 1, column: 5, endLine: 1, endColumn: 10,
+  },
+]

--- a/test/invalid/vue-02.txt
+++ b/test/invalid/vue-02.txt
@@ -1,0 +1,28 @@
+CODE:
+<template>
+  <div></div>
+</template>
+
+<script>
+console.log('hello');
+</script>
+
+OUTPUT:
+<template>
+  <div></div>
+</template>
+
+<script>
+console.log("hello");
+</script>
+
+OPTIONS:
+[]
+
+ERRORS:
+[
+  {
+    message: 'Replace `\'hello\'` with `"hello"`',
+    line: 6, column: 13, endLine: 6, endColumn: 20,
+  },
+]

--- a/test/invalid/vue-03.txt
+++ b/test/invalid/vue-03.txt
@@ -1,0 +1,26 @@
+CODE:
+<template></template>
+
+<script>
+/** @format */
+f('');
+</script>
+
+OUTPUT:
+<template></template>
+
+<script>
+/** @format */
+f("");
+</script>
+
+OPTIONS:
+[null, '@format']
+
+ERRORS:
+[
+  {
+    message: 'Replace `\'\'` with `""`',
+    line: 5, column: 3, endLine: 5, endColumn: 5,
+  },
+]

--- a/test/invalid/vue-04.txt
+++ b/test/invalid/vue-04.txt
@@ -1,0 +1,30 @@
+CODE:
+<script>
+// Known problem: we are not fixing indentation for the first line
+    var App = {
+    name: "App"
+    };
+</script>
+
+OUTPUT:
+<script>
+// Known problem: we are not fixing indentation for the first line
+    var App = {
+  name: "App"
+};
+</script>
+
+OPTIONS:
+[]
+
+ERRORS:
+[
+  {
+    message: 'Delete `··`',
+    line: 4, column: 3, endLine: 4, endColumn: 5,
+  },
+  {
+    message: 'Delete `····`',
+    line: 5, column: 1, endLine: 5, endColumn: 5,
+  },
+]

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -26,6 +26,7 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const vueRuleTester = new RuleTester({ parser: 'vue-eslint-parser' });
 
 ruleTester.run('prettier', rule, {
   valid: [
@@ -79,6 +80,23 @@ ruleTester.run('prettier', rule, {
     '18',
     '19'
   ].map(loadInvalidFixture)
+});
+
+vueRuleTester.run('prettier', rule, {
+  valid: [
+    { code: 'var foo = { bar: 0 };\n' },
+    { code: '<template></template>' },
+    { code: '<script></script>' },
+    { code: '<script>\nvar foo = { bar: 0 };</script>' },
+    {
+      code: `<script>\n/** @format */\n('');</script>`,
+      options: ['fb', '@format']
+    },
+    {
+      code: '<script>\r\nvar f = { bar: 0 };\r\nvar b = { f: f };\r\n</script>'
+    }
+  ],
+  invalid: ['vue-01', 'vue-02', 'vue-03', 'vue-04'].map(loadInvalidFixture)
 });
 
 describe('generateDifferences', () => {

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -82,22 +82,25 @@ ruleTester.run('prettier', rule, {
   ].map(loadInvalidFixture)
 });
 
-vueRuleTester.run('prettier', rule, {
-  valid: [
-    { code: 'var foo = { bar: 0 };\n' },
-    { code: '<template></template>' },
-    { code: '<script></script>' },
-    { code: '<script>\nvar foo = { bar: 0 };</script>' },
-    {
-      code: `<script>\n/** @format */\n('');</script>`,
-      options: ['fb', '@format']
-    },
-    {
-      code: '<script>\r\nvar f = { bar: 0 };\r\nvar b = { f: f };\r\n</script>'
-    }
-  ],
-  invalid: ['vue-01', 'vue-02', 'vue-03', 'vue-04'].map(loadInvalidFixture)
-});
+if (!process.env.ESLINT_VERSION || process.env.ESLINT_VERSION !== '3.15.0') {
+  vueRuleTester.run('prettier', rule, {
+    valid: [
+      { code: 'var foo = { bar: 0 };\n' },
+      { code: '<template></template>' },
+      { code: '<script></script>' },
+      { code: '<script>\nvar foo = { bar: 0 };</script>' },
+      {
+        code: `<script>\n/** @format */\n('');</script>`,
+        options: ['fb', '@format']
+      },
+      {
+        code:
+          '<script>\r\nvar f = { bar: 0 };\r\nvar b = { f: f };\r\n</script>'
+      }
+    ],
+    invalid: ['vue-01', 'vue-02', 'vue-03', 'vue-04'].map(loadInvalidFixture)
+  });
+}
 
 describe('generateDifferences', () => {
   it('operation: insert', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@ acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
+acorn@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -162,6 +166,12 @@ debug@2.6.0, debug@^2.1.1:
   dependencies:
     ms "0.7.2"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -282,6 +292,13 @@ eslint-plugin-self@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-self/-/eslint-plugin-self-1.0.1.tgz#50efd8acf33a399670b7ce7c12b2fd9868b41e7e"
 
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint@^3.14.1:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
@@ -327,6 +344,13 @@ espree@^3.4.0:
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
     acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  dependencies:
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.1:
@@ -643,7 +667,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -686,6 +710,10 @@ moment@^2.18.1:
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -947,6 +975,16 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+vue-eslint-parser@^2.0.1-beta.2:
+  version "2.0.1-beta.2"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.1-beta.2.tgz#82e5130ac18ae4b0c894a7c831b55ec92478fa2f"
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    espree "^3.5.1"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hey,
It is intended to be used with upcoming [vue-eslint-parser](https://github.com/mysticatea/vue-eslint-parser) v2 that is used by upcoming [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue) v4.
You can find examples of .vue files in [GitLab](https://gitlab.com/gitlab-org/gitlab-ce/tree/master/app/assets/javascripts/groups/components) or [OnsenUI](https://github.com/OnsenUI/OnsenUI/tree/master/bindings/vue/src/components).