### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -301,6 +301,9 @@ module.exports = {
   rules: {
     prettier: {
       meta: {
+        docs: {
+          url: 'https://github.com/prettier/eslint-plugin-prettier#options'
+        },
         fixable: 'code',
         schema: [
           // Prettier options:


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.