### PR TITLE
Fix: pass filepath to prettier

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -371,7 +371,8 @@ module.exports = {
             const prettierOptions = Object.assign(
               {},
               prettierRcOptions,
-              eslintPrettierOptions
+              eslintPrettierOptions,
+              { filepath: context.getFilename() }
             );
 
             const prettierSource = prettier.format(source, prettierOptions);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-self": "^1.0.1",
     "mocha": "^3.1.2",
     "moment": "^2.18.1",
-    "prettier": "^1.6.1",
+    "prettier": "^1.10.2",
     "semver": "^5.3.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,9 +762,9 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prettier@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"


### PR DESCRIPTION
Passing the filepath to Prettier allows Prettier to determine which parser to use dynamically. This has the effect of fixing the integration between `eslint-plugin-vue` or `eslint-plugin-html` and `eslint-plugin-prettier`, but is not specific to those plugins.

Here's a test showing the output after this fix: https://github.com/azz/eslint-vue-prettier-repro

I added a test to this repo but could not commit it as it depends on a HTML parser being loaded.