### PR TITLE
New: Support usage alongside eslint-plugin-vue

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -360,19 +360,24 @@ module.exports = {
               prettier = require('prettier');
             }
 
+            const filename = context.getFilename();
             const eslintPrettierOptions =
               context.options[0] === 'fb'
                 ? FB_PRETTIER_OPTIONS
                 : context.options[0];
             const prettierRcOptions =
               prettier.resolveConfig && prettier.resolveConfig.sync
-                ? prettier.resolveConfig.sync(context.getFilename())
+                ? prettier.resolveConfig.sync(filename)
                 : null;
             const prettierOptions = Object.assign(
               {},
               prettierRcOptions,
               eslintPrettierOptions
             );
+
+            if (/\.vue$/.test(filename)) {
+              prettierOptions.parser = 'vue';
+            }
 
             const prettierSource = prettier.format(source, prettierOptions);
             if (source !== prettierSource) {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "eslint-plugin-self": "^1.0.1",
     "mocha": "^3.1.2",
     "moment": "^2.18.1",
-    "prettier": "^1.6.1",
-    "semver": "^5.3.0"
+    "prettier": "^1.10.2",
+    "semver": "^5.3.0",
+    "vue-eslint-parser": "^2.0.2"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/invalid/vue.txt
+++ b/test/invalid/vue.txt
@@ -1,0 +1,26 @@
+CODE:
+<template>
+  <div>hi</div>
+</template>
+<script>
+a();;;;;;
+</script>
+
+OUTPUT:
+<template>
+  <div>hi</div>
+</template>
+<script>
+a();
+</script>
+
+OPTIONS:
+[]
+
+ERRORS:
+[
+  {
+    message: 'Delete `;;;;;`',
+    line: 5, column: 5, endLine: 5, endColumn: 10,
+  },
+]

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -81,6 +81,24 @@ ruleTester.run('prettier', rule, {
   ].map(loadInvalidFixture)
 });
 
+const vueRuleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser')
+});
+
+vueRuleTester.run('prettier', rule, {
+  valid: [
+    {
+      code: `<template>foo</template>\n<script>\n"";\n</script>\n`,
+      filename: 'valid.vue'
+    }
+  ],
+  invalid: [
+    Object.assign(loadInvalidFixture('vue'), {
+      filename: 'invalid.vue'
+    })
+  ]
+});
+
 describe('generateDifferences', () => {
   it('operation: insert', () => {
     const differences = eslintPluginPrettier.generateDifferences(

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@ acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
 ajv-keywords@^1.0.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
@@ -162,6 +166,12 @@ debug@2.6.0, debug@^2.1.1:
   dependencies:
     ms "0.7.2"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -282,6 +292,17 @@ eslint-plugin-self@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-self/-/eslint-plugin-self-1.0.1.tgz#50efd8acf33a399670b7ce7c12b2fd9868b41e7e"
 
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
 eslint@^3.14.1:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
@@ -327,6 +348,13 @@ espree@^3.4.0:
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
     acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  dependencies:
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.1:
@@ -643,7 +671,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -686,6 +714,10 @@ moment@^2.18.1:
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -762,9 +794,9 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prettier@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -947,6 +979,17 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+vue-eslint-parser@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.2.tgz#8d603545e9d7c134699075bd1772af1ffd86b744"
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Now that Prettier core 1.10 supports Vue files, we are trying to integrate this plugin to be used alongside [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue), which uses `vue-eslint-parser` and allows ESLint to directly lint `*.vue` files.

To get it working together though, we need to explicitly set prettier's parser to `vue` when a vue file is encountered in this plugin. Otherwise prettier parses the vue file as JavaScript and throws syntax errors.

/cc @vjeux 