### PR TITLE
New: option `withNodeModules` to unignore `node_modules` folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ For the list of every available exclusion rule set, please see the [readme of es
       }]
       ```
 
+    - `withNodeModules`: Prettier ignores files located in `node_modules` directories. To opt-out from this behavior set `true`, (default: `false`). May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.
+    
+      ```json
+      "prettier/prettier": ["error", {}, {
+        "withNodeModules": true
+      }]
+      ```
+
 - The rule is autofixable -- if you run `eslint` with the `--fix` flag, your code will be formatted according to `prettier` style.
 
 ---

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ For the list of every available exclusion rule set, please see the [readme of es
       }]
       ```
 
-    - `withNodeModules`: Prettier ignores files located in `node_modules` directories. To opt-out from this behavior set `false`, (default: `true`). May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.
+    - `withNodeModules`: Prettier ignores files located in `node_modules` directories. To opt-out from this behavior set `true`, (default: `false`). May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.
     
       ```json
       "prettier/prettier": ["error", {}, {
-        "withNodeModules": false
+        "withNodeModules": true
       }]
       ```
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ For the list of every available exclusion rule set, please see the [readme of es
       }]
       ```
 
-    - `withNodeModules`: Prettier ignores files located in `node_modules` directories. To opt-out from this behavior set `true`, (default: `false`). May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.
+    - `withNodeModules`: Prettier ignores files located in `node_modules` directories. To opt-out from this behavior set `false`, (default: `true`). May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.
     
       ```json
       "prettier/prettier": ["error", {}, {
-        "withNodeModules": true
+        "withNodeModules": false
       }]
       ```
 

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -142,7 +142,7 @@ module.exports = {
         const usePrettierrc =
           !context.options[1] || context.options[1].usePrettierrc !== false;
         const withNodeModules =
-          !context.options[1] || context.options[1].withNodeModules !== false;
+          context.options[1] && context.options[1].withNodeModules !== false;
         const sourceCode = context.getSourceCode();
         const filepath = context.getFilename();
         const source = sourceCode.text;

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -131,7 +131,8 @@ module.exports = {
           {
             type: 'object',
             properties: {
-              usePrettierrc: { type: 'boolean' }
+              usePrettierrc: { type: 'boolean' },
+              withNodeModules: { type: 'boolean' }
             },
             additionalProperties: true
           }
@@ -140,6 +141,8 @@ module.exports = {
       create(context) {
         const usePrettierrc =
           !context.options[1] || context.options[1].usePrettierrc !== false;
+        const withNodeModules =
+          context.options[1] && context.options[1].withNodeModules !== false;
         const sourceCode = context.getSourceCode();
         const filepath = context.getFilename();
         const source = sourceCode.text;
@@ -164,7 +167,8 @@ module.exports = {
               : null;
 
             const prettierFileInfo = prettier.getFileInfo.sync(filepath, {
-              ignorePath: '.prettierignore'
+              ignorePath: '.prettierignore',
+              withNodeModules
             });
 
             // Skip if file is ignored using a .prettierignore file

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -142,7 +142,7 @@ module.exports = {
         const usePrettierrc =
           !context.options[1] || context.options[1].usePrettierrc !== false;
         const withNodeModules =
-          context.options[1] && context.options[1].withNodeModules !== false;
+          !context.options[1] || context.options[1].withNodeModules !== false;
         const sourceCode = context.getSourceCode();
         const filepath = context.getFilename();
         const source = sourceCode.text;

--- a/test/invalid/18.txt
+++ b/test/invalid/18.txt
@@ -1,0 +1,19 @@
+CODE:
+a();;;;
+
+OUTPUT:
+a();
+
+OPTIONS:
+[{}, { withNodeModules: true }]
+
+ERRORS:
+[
+  {
+    message: 'Delete `;;;`',
+    line: 1, column: 5, endLine: 1, endColumn: 8,
+  },
+]
+
+FILENAME:
+node_modules/dummy.js

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -61,6 +61,17 @@ ruleTester.run('prettier', rule, {
     {
       code: `('');\n`,
       filename: getPrettierRcJsFilename('single-quote', 'dummy.md')
+    },
+    // Should ignore files from node_modules
+    {
+      code: 'a();;;;;;\n',
+      filename: 'node_modules/dummy.js'
+    },
+    // Should check files from node_modules too
+    {
+      code: 'a();\n',
+      filename: 'node_modules/dummy.js',
+      options: [{}, { withNodeModules: true }]
     }
   ],
   invalid: [
@@ -81,7 +92,8 @@ ruleTester.run('prettier', rule, {
     '14',
     '15',
     '16',
-    '17'
+    '17',
+    '18'
   ].map(loadInvalidFixture)
 });
 
@@ -127,6 +139,9 @@ function loadInvalidFixture(name) {
     options: eval(sections[3]), // eslint-disable-line no-eval
     errors: eval(sections[4]) // eslint-disable-line no-eval
   };
+  if (sections.length >= 6) {
+    item.filename = sections[5];
+  }
   return item;
 }
 


### PR DESCRIPTION
This PR add option `withNodeModules` (default: `false`) to unignore `node_modules` folders. May be useful if you are using multiple `node_modules` directories, example to avoid many `../..` sequences.