### PR TITLE
Catch and format SyntaxErrors as eslint violations

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-self": "^1.1.0",
     "mocha": "^5.2.0",
-    "prettier": "^1.13.0",
+    "prettier": "^1.15.3",
     "vue-eslint-parser": "^4.0.2"
   },
   "engines": {

--- a/test/invalid/vue-syntax-error.txt
+++ b/test/invalid/vue-syntax-error.txt
@@ -1,0 +1,26 @@
+CODE:
+<template>
+  <div>
+</template>
+<script>
+a();
+</script>
+
+OUTPUT:
+<template>
+  <div>
+</template>
+<script>
+a();
+</script>
+
+OPTIONS:
+[]
+
+ERRORS:
+[
+  {
+    message: 'Parsing error: Unexpected closing tag "template". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+    line: 3, column: 2
+  },
+]

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -99,6 +99,9 @@ vueRuleTester.run('prettier', rule, {
   invalid: [
     Object.assign(loadInvalidFixture('vue'), {
       filename: 'invalid.vue'
+    }),
+    Object.assign(loadInvalidFixture('vue-syntax-error'), {
+      filename: 'syntax-error.vue'
     })
   ]
 });

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -92,7 +92,7 @@ const vueRuleTester = new RuleTester({
 vueRuleTester.run('prettier', rule, {
   valid: [
     {
-      code: `<template>foo</template>\n<script>\n"";\n</script>\n`,
+      code: `<template>\n  <div>HI</div>\n</template>\n<script>\n3;\n</script>\n`,
       filename: 'valid.vue'
     }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,9 +679,9 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.13.0:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+prettier@^1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
 
 progress@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
If Prettier can't format a file due to not being able to parse the given
content it throws a SyntaxError. If that happens then announce the
error as an ESLint rule violation instead of crashing.

The most plausible form of SyntaxErrors are when vue files contain invalid HTML such as no self-closing tags (e.g. `<template><div></template>` is invalid due to there being no `</div>`

Fixes #140.