### PR TITLE
Fixes pluginSearchDirs w/ getFileInfo

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -163,9 +163,15 @@ module.exports = {
                 })
               : null;
 
-            const prettierFileInfo = prettier.getFileInfo.sync(filepath, {
-              ignorePath: '.prettierignore'
-            });
+            const prettierFileInfo = prettier.getFileInfo.sync(
+              filepath,
+              Object.assign(
+                {
+                  ignorePath: '.prettierignore'
+                },
+                prettierRcOptions
+              )
+            );
 
             // Skip if file is ignored using a .prettierignore file
             if (prettierFileInfo.ignored) {


### PR DESCRIPTION
This plugin wasn't properly forwarding the `pluginSearchDirs` option to Prettier, causing unexpected issues in some cases. This diff simply makes sure that the options are merged with the rc settings that are read right before.