### PR TITLE
Allow to specify the path to Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ For the list of every available exclusion rule set, please see the [readme of es
       }]
       ```
 
+    - `prettier`: If supplied, this is a custom path to where `prettier` can be found. This is very useful if you are using Yarn PNP or similar and Prettier isn't installed at the root of the project. Defaults to `require.resolve("prettier")`.
+
 - The rule is autofixable -- if you run `eslint` with the `--fix` flag, your code will be formatted according to `prettier` style.
 
 ---

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -21,13 +21,6 @@ const {
 const { INSERT, DELETE, REPLACE } = generateDifferences;
 
 // ------------------------------------------------------------------------------
-//  Privates
-// ------------------------------------------------------------------------------
-
-// Lazily-loaded Prettier.
-let prettier;
-
-// ------------------------------------------------------------------------------
 //  Rule Definition
 // ------------------------------------------------------------------------------
 
@@ -136,7 +129,8 @@ module.exports = {
                 type: 'object',
                 properties: {},
                 additionalProperties: true
-              }
+              },
+              prettier: { type: 'string' }
             },
             additionalProperties: true
           }
@@ -147,9 +141,14 @@ module.exports = {
           !context.options[1] || context.options[1].usePrettierrc !== false;
         const eslintFileInfoOptions =
           (context.options[1] && context.options[1].fileInfoOptions) || {};
+        const prettierPackage =
+          (context.options[1] && context.options[1].prettier) || 'prettier';
         const sourceCode = context.getSourceCode();
         const filepath = context.getFilename();
         const source = sourceCode.text;
+
+        // Lazily-loaded Prettier.
+        let prettier;
 
         if (prettier && prettier.clearConfigCache) {
           prettier.clearConfigCache();
@@ -159,7 +158,7 @@ module.exports = {
           Program() {
             if (!prettier) {
               // Prettier is expensive to load, so only load it if needed.
-              prettier = require('prettier');
+              prettier = require(prettierPackage);
             }
 
             const eslintPrettierOptions = context.options[0] || {};


### PR DESCRIPTION
Hello @not-an-aardvark and @BPScott ,

as explained in #197, in some cases, having Prettier as a peer dependency is not ideal, for example in a mulitmodule project or with Yarn PNP.

This pull request allows, for those who need it, to specify the full path to the prettier package with `require.resolve("prettier")` from the package that has it as a dependency.
