### PR TITLE
Update: Rename babylon parser to babel

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -210,7 +210,7 @@ module.exports = {
             if (
               parserBlocklist.indexOf(prettierFileInfo.inferredParser) !== -1
             ) {
-              initialOptions.parser = 'babylon';
+              initialOptions.parser = 'babel';
             }
 
             const prettierOptions = Object.assign(


### PR DESCRIPTION
Prevent message : { parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.

Related : https://github.com/prettier/prettier/pull/5647