### PR TITLE
Bump Prettier version to 1.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-self": "^1.1.0",
     "mocha": "^6.0.0",
-    "prettier": "^1.15.3",
+    "prettier": "^1.18.2",
     "vue-eslint-parser": "^6.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,9 +808,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.15.3:
+prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 progress@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Current version of prettier ignores (some) configuration options form .prettierrc.
With 1.18.2 all of the options are correctly applied.

Should fix https://github.com/prettier/eslint-plugin-prettier/issues/184 as well.