### PR TITLE
fix: add eslint-config-prettier to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/prettier/eslint-plugin-prettier#readme",
   "dependencies": {
+    "eslint-config-prettier": "^6.0.0",
     "prettier-linter-helpers": "^1.0.0"
   },
   "peerDependencies": {
@@ -38,7 +39,6 @@
     "@not-an-aardvark/node-release-script": "^0.1.0",
     "eslint": "^6.0.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
-    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-eslint-plugin": "^2.0.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-self": "^1.1.0",


### PR DESCRIPTION
If this plugin is used with pnpm eslint fails because it can not find `eslint-config-prettier` in the non-flat `node_modules`.

This PR adds `eslint-config-prettier` to the `dependencies`.

Another solution would be to add `eslint-config-prettier` to the `peerDependencies`. I would change the PR if that would be the better choice.