### PR TITLE
Resolve config when getting list of inferred parsers

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -174,7 +174,7 @@ module.exports = {
               filepath,
               Object.assign(
                 {},
-                { ignorePath: '.prettierignore' },
+                { resolveConfig: true, ignorePath: '.prettierignore' },
                 eslintFileInfoOptions
               )
             );


### PR DESCRIPTION
This lets custom file types specified in prettierrc be found if you're
using prettier v1.19