### PR TITLE
Prettier 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,12 @@ module.exports = {
     'not-an-aardvark/node',
     'plugin:node/recommended',
     'plugin:eslint-plugin/recommended',
-    'prettier'
+    'prettier',
   ],
   env: { mocha: true },
   root: true,
   rules: {
     'self/prettier': ['error'],
-    'eslint-plugin/report-message-format': ['error', '^[^a-z].*\\.$']
-  }
+    'eslint-plugin/report-message-format': ['error', '^[^a-z].*\\.$'],
+  },
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: node_js
 cache: yarn
 node_js:
-  - "10"
-  - "8"
-  - "6"
+  - '10'
+  - '8'
+  - '6'
 env:
   - ESLINT_VERSION=current
   - ESLINT_VERSION=^5
 matrix:
   exclude:
     # eslint 6 only supports node >=8.10
-    - node_js: "6"
+    - node_js: '6'
       env: ESLINT_VERSION=current
 install:
   - if [[ $ESLINT_VERSION != "current" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 cache: yarn
 node_js:
+  - '12'
   - '10'
-  - '8'
-  - '6'
 env:
   - ESLINT_VERSION=current
   - ESLINT_VERSION=^5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,6 @@ cache: yarn
 node_js:
   - '12'
   - '10'
-env:
-  - ESLINT_VERSION=current
-  - ESLINT_VERSION=^5
-matrix:
-  exclude:
-    # eslint 6 only supports node >=8.10
-    - node_js: '6'
-      env: ESLINT_VERSION=current
 install:
-  - if [[ $ESLINT_VERSION != "current" ]]; then
-    yarn upgrade "eslint@$ESLINT_VERSION";
-    fi
   - yarn install
   - yarn run --silent eslint --version

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -11,7 +11,7 @@
 
 const {
   showInvisibles,
-  generateDifferences
+  generateDifferences,
 } = require('prettier-linter-helpers');
 
 // ------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ function reportInsert(context, offset, text) {
     loc: { start: pos, end: pos },
     fix(fixer) {
       return fixer.insertTextAfterRange(range, text);
-    }
+    },
   });
 }
 
@@ -68,7 +68,7 @@ function reportDelete(context, offset, text) {
     loc: { start, end },
     fix(fixer) {
       return fixer.removeRange(range);
-    }
+    },
   });
 }
 
@@ -91,12 +91,12 @@ function reportReplace(context, offset, deleteText, insertText) {
     message: 'Replace `{{ deleteCode }}` with `{{ insertCode }}`',
     data: {
       deleteCode: showInvisibles(deleteText),
-      insertCode: showInvisibles(insertText)
+      insertCode: showInvisibles(insertText),
     },
     loc: { start, end },
     fix(fixer) {
       return fixer.replaceTextRange(range, insertText);
-    }
+    },
   });
 }
 
@@ -110,15 +110,15 @@ module.exports = {
       extends: ['prettier'],
       plugins: ['prettier'],
       rules: {
-        'prettier/prettier': 'error'
-      }
-    }
+        'prettier/prettier': 'error',
+      },
+    },
   },
   rules: {
     prettier: {
       meta: {
         docs: {
-          url: 'https://github.com/prettier/eslint-plugin-prettier#options'
+          url: 'https://github.com/prettier/eslint-plugin-prettier#options',
         },
         type: 'layout',
         fixable: 'code',
@@ -127,7 +127,7 @@ module.exports = {
           {
             type: 'object',
             properties: {},
-            additionalProperties: true
+            additionalProperties: true,
           },
           {
             type: 'object',
@@ -136,12 +136,12 @@ module.exports = {
               fileInfoOptions: {
                 type: 'object',
                 properties: {},
-                additionalProperties: true
-              }
+                additionalProperties: true,
+              },
             },
-            additionalProperties: true
-          }
-        ]
+            additionalProperties: true,
+          },
+        ],
       },
       create(context) {
         const usePrettierrc =
@@ -167,7 +167,7 @@ module.exports = {
 
             const prettierRcOptions = usePrettierrc
               ? prettier.resolveConfig.sync(filepath, {
-                  editorconfig: true
+                  editorconfig: true,
                 })
               : null;
 
@@ -215,7 +215,9 @@ module.exports = {
               // Use the modern name if available
               const supportBabelParser = prettier
                 .getSupportInfo()
-                .languages.some(language => language.parsers.includes('babel'));
+                .languages.some((language) =>
+                  language.parsers.includes('babel')
+                );
 
               initialOptions.parser = supportBabelParser ? 'babel' : 'babylon';
             }
@@ -265,7 +267,7 @@ module.exports = {
             if (source !== prettierSource) {
               const differences = generateDifferences(source, prettierSource);
 
-              differences.forEach(difference => {
+              differences.forEach((difference) => {
                 switch (difference.operation) {
                   case INSERT:
                     reportInsert(
@@ -292,9 +294,9 @@ module.exports = {
                 }
               });
             }
-          }
+          },
         };
-      }
-    }
-  }
+      },
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-self": "^1.1.0",
     "mocha": "^6.0.0",
-    "prettier": "^1.15.3",
+    "prettier": "^2.0.5",
     "vue-eslint-parser": "^6.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue-eslint-parser": "^7.0.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.13.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "prettier-linter-helpers": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=5.0.0",
+    "eslint": ">=6.8.0",
     "prettier": ">=2.0.5"
   },
   "devDependencies": {
     "@not-an-aardvark/node-release-script": "^0.1.0",
-    "eslint": "^6.0.0",
+    "eslint": "^6.8.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-plugin": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -31,20 +31,20 @@
     "prettier-linter-helpers": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": ">= 5.0.0",
-    "prettier": ">= 1.13.0"
+    "eslint": ">=5.0.0",
+    "prettier": ">=2.0.5"
   },
   "devDependencies": {
     "@not-an-aardvark/node-release-script": "^0.1.0",
     "eslint": "^6.0.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
-    "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-eslint-plugin": "^2.0.0",
-    "eslint-plugin-node": "^8.0.0",
-    "eslint-plugin-self": "^1.1.0",
-    "mocha": "^6.0.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-eslint-plugin": "^2.2.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-self": "^1.2.0",
+    "mocha": "^7.1.1",
     "prettier": "^2.0.5",
-    "vue-eslint-parser": "^6.0.0"
+    "vue-eslint-parser": "^7.0.0"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/test/invalid/10.txt
+++ b/test/invalid/10.txt
@@ -5,7 +5,7 @@ b: 1
 
 OUTPUT:
 var a = {
-	b: 1
+	b: 1,
 };
 
 OPTIONS:
@@ -14,7 +14,7 @@ OPTIONS:
 ERRORS:
 [
   {
-    message: 'Insert `↹`',
-    line: 2, column: 1, endLine: 2, endColumn: 1,
+    message: 'Replace `b:·1` with `↹b:·1,`',
+    line: 2, column: 1, endLine: 2, endColumn: 5,
   },
 ]

--- a/test/invalid/11-a.txt
+++ b/test/invalid/11-a.txt
@@ -5,7 +5,7 @@ var a = {
 
 OUTPUT:
 var a = {
-  b: ""
+  b: "",
 };
 
 OPTIONS:
@@ -14,7 +14,7 @@ OPTIONS:
 ERRORS:
 [
   {
-    message: 'Replace `\'\',` with `""`',
-    line: 2, column: 6, endLine: 2, endColumn: 9,
+    message: 'Replace `\'\'` with `""`',
+    line: 2, column: 6, endLine: 2, endColumn: 8,
   },
 ]

--- a/test/invalid/11-b.txt
+++ b/test/invalid/11-b.txt
@@ -5,7 +5,7 @@ var a = {
 
 OUTPUT:
 var a = {
-  b: ""
+  b: "",
 };
 
 OPTIONS:
@@ -14,7 +14,7 @@ OPTIONS:
 ERRORS:
 [
   {
-    message: 'Replace `\'\',` with `""`',
-    line: 2, column: 6, endLine: 2, endColumn: 9,
+    message: 'Replace `\'\'` with `""`',
+    line: 2, column: 6, endLine: 2, endColumn: 8,
   },
 ]

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -36,23 +36,23 @@ ruleTester.run('prettier', rule, {
     {
       code: `var foo = {bar: 0};\n`,
       filename: getPrettierRcJsFilename('bracket-spacing'),
-      options: [{ bracketSpacing: false }]
+      options: [{ bracketSpacing: false }],
     },
     // Only use options from plugin, skipping .prettierrc
     {
       code: `var foo = {bar: 0};\n`,
       filename: getPrettierRcJsFilename('bracket-spacing'),
-      options: [{ bracketSpacing: false }, { usePrettierrc: false }]
+      options: [{ bracketSpacing: false }, { usePrettierrc: false }],
     },
     // Ignores filenames in .prettierignore
     {
       code: `("");\n`,
-      filename: getPrettierRcJsFilename('single-quote', 'ignore-me.js')
+      filename: getPrettierRcJsFilename('single-quote', 'ignore-me.js'),
     },
     // Sets a default parser when it can't be inferred from the file extensions
     {
       code: `('');\n`,
-      filename: getPrettierRcJsFilename('single-quote', 'dummy.qqq')
+      filename: getPrettierRcJsFilename('single-quote', 'dummy.qqq'),
     },
     // Overwrites the parser for file extensions prettier would try to format
     // with not the babylon parser
@@ -60,13 +60,13 @@ ruleTester.run('prettier', rule, {
     // into JS snippets that would get passed to ESLint
     {
       code: `('');\n`,
-      filename: getPrettierRcJsFilename('single-quote', 'dummy.md')
+      filename: getPrettierRcJsFilename('single-quote', 'dummy.md'),
     },
     // Should ignore files from node_modules
     {
       code: 'a();;;;;;\n',
-      filename: 'node_modules/dummy.js'
-    }
+      filename: 'node_modules/dummy.js',
+    },
   ],
   invalid: [
     '01',
@@ -87,29 +87,29 @@ ruleTester.run('prettier', rule, {
     '15',
     '16',
     '17',
-    '18'
-  ].map(loadInvalidFixture)
+    '18',
+  ].map(loadInvalidFixture),
 });
 
 const vueRuleTester = new RuleTester({
-  parser: require.resolve('vue-eslint-parser')
+  parser: require.resolve('vue-eslint-parser'),
 });
 
 vueRuleTester.run('prettier', rule, {
   valid: [
     {
       code: `<template>\n  <div>HI</div>\n</template>\n<script>\n3;\n</script>\n`,
-      filename: 'valid.vue'
-    }
+      filename: 'valid.vue',
+    },
   ],
   invalid: [
     Object.assign(loadInvalidFixture('vue'), {
-      filename: 'invalid.vue'
+      filename: 'invalid.vue',
     }),
     Object.assign(loadInvalidFixture('vue-syntax-error'), {
-      filename: 'syntax-error.vue'
-    })
-  ]
+      filename: 'syntax-error.vue',
+    }),
+  ],
 });
 
 // ------------------------------------------------------------------------------
@@ -129,13 +129,13 @@ function loadInvalidFixture(name) {
   const src = fs.readFileSync(filename, 'utf8');
   const sections = src
     .split(/^[A-Z]+:\n/m)
-    .map(x => x.replace(/(?=\n)\n$/, ''));
+    .map((x) => x.replace(/(?=\n)\n$/, ''));
   const item = {
     code: sections[1],
     output: sections[2],
     options: eval(sections[3]), // eslint-disable-line no-eval
     errors: eval(sections[4]), // eslint-disable-line no-eval
-    filename: getPrettierRcJsFilename('double-quote', name + '.txt')
+    filename: getPrettierRcJsFilename('double-quote', name + '.txt'),
   };
   if (sections.length >= 6) {
     item.filename = sections[5];

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,17 +23,9 @@
     moment "^2.18.1"
     semver "^5.4.1"
 
-acorn-jsx@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
-
 acorn-jsx@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
-
-acorn@^6.0.7:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
 
 acorn@^7.1.0:
   version "7.1.0"
@@ -72,6 +64,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -86,12 +86,24 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -105,7 +117,7 @@ camelcase@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -116,6 +128,21 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+
+chokidar@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
+  integrity sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.2.0"
+  optionalDependencies:
+    fsevents "~2.1.1"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -230,44 +257,42 @@ eslint-config-not-an-aardvark@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-not-an-aardvark/-/eslint-config-not-an-aardvark-2.1.0.tgz#71e5fb7c43b64abb4632ef144aad6cceef520195"
 
-eslint-config-prettier@^6.0.0:
+eslint-config-prettier@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
+  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-es@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz#5acb2565db4434803d1d46a9b4cbc94b345bd028"
+eslint-plugin-es@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz#98cb1bc8ab0aa807977855e11ad9d1c9422d014b"
+  integrity sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==
   dependencies:
-    eslint-utils "^1.3.0"
-    regexpp "^2.0.0"
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
 
-eslint-plugin-eslint-plugin@^2.0.0:
+eslint-plugin-eslint-plugin@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.2.1.tgz#9d567f2bb6891935d5d3e741f66c9ac42dc688fd"
+  integrity sha512-nvmoefIqdFX+skyCt/dN9HaeSNyL8A9UvEtCqCFfJBjKpAR0uRL3SGPLlvDsnfXWtN72G/viowvpA33VjQkGCg==
 
-eslint-plugin-node@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz#55ae3560022863d141fa7a11799532340a685964"
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
   dependencies:
-    eslint-plugin-es "^1.3.1"
-    eslint-utils "^1.3.1"
-    ignore "^5.0.2"
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
     minimatch "^3.0.4"
-    resolve "^1.8.1"
-    semver "^5.5.0"
+    resolve "^1.10.1"
+    semver "^6.1.0"
 
-eslint-plugin-self@^1.1.0:
+eslint-plugin-self@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-self/-/eslint-plugin-self-1.2.0.tgz#b999cfed88b893afa6b1f7ce7037d208ede9b8ba"
-
-eslint-scope@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
+  integrity sha512-veuI/YC7DHJI4/rPlYxnZpszW7aSjwWj2/zZQ4UCWJE+tDgF853jJlz5UhPd/ckLYaMJXewZdKx6nSpWC2Ncqw==
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -276,13 +301,20 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.0, eslint-utils@^1.3.1, eslint-utils@^1.4.3:
+eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
 
@@ -327,14 +359,6 @@ eslint@^6.0.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
-
-espree@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
 
 espree@^6.1.2:
   version "6.1.2"
@@ -404,6 +428,13 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -432,6 +463,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fsevents@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
+  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -451,6 +487,13 @@ get-stdin@^6.0.0:
 glob-parent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
 
@@ -503,9 +546,10 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
-ignore@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.0.4.tgz#33168af4a21e99b00c5d41cbadb6a6cb49903a45"
+ignore@^5.1.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 import-fresh@^3.0.0:
   version "3.0.0"
@@ -547,6 +591,13 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
@@ -571,11 +622,16 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   dependencies:
     is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -634,11 +690,12 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
-log-symbols@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+log-symbols@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   dependencies:
-    chalk "^2.0.1"
+    chalk "^2.4.2"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -654,18 +711,32 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+mkdirp@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
+  dependencies:
+    minimist "^1.2.5"
+
+mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^6.0.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.2.tgz#5d8987e28940caf8957a7d7664b910dc5b2fea20"
+mocha@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.1.tgz#89fbb30d09429845b1bb893a830bf5771049a441"
+  integrity sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==
   dependencies:
     ansi-colors "3.2.3"
     browser-stdout "1.3.1"
+    chokidar "3.3.0"
     debug "3.2.6"
     diff "3.5.0"
     escape-string-regexp "1.0.5"
@@ -674,18 +745,18 @@ mocha@^6.0.0:
     growl "1.10.5"
     he "1.2.0"
     js-yaml "3.13.1"
-    log-symbols "2.2.0"
+    log-symbols "3.0.0"
     minimatch "3.0.4"
-    mkdirp "0.5.1"
+    mkdirp "0.5.3"
     ms "2.1.1"
-    node-environment-flags "1.0.5"
+    node-environment-flags "1.0.6"
     object.assign "4.1.0"
     strip-json-comments "2.0.1"
     supports-color "6.0.0"
     which "1.3.1"
     wide-align "1.1.3"
-    yargs "13.3.0"
-    yargs-parser "13.1.1"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
 moment@^2.18.1:
@@ -708,12 +779,18 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
-node-environment-flags@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
+node-environment-flags@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
+  integrity sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
+
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.0"
@@ -796,9 +873,15 @@ path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+picomatch@^2.0.4:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -822,9 +905,21 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-regexpp@^2.0.0, regexpp@^2.0.1:
+readdirp@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
+  integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
+  dependencies:
+    picomatch "^2.0.4"
+
+regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+
+regexpp@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -838,11 +933,12 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
-resolve@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+resolve@^1.10.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
+  integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -876,6 +972,11 @@ rxjs@^6.4.0:
 semver@^5.4.1, semver@^5.5.0, semver@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+
+semver@^6.1.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^6.1.2:
   version "6.2.0"
@@ -997,6 +1098,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -1025,16 +1133,17 @@ v8-compile-cache@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
 
-vue-eslint-parser@^6.0.0:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-6.0.4.tgz#56ff47e2c2644bff39951d5a284982c7ecd6f7fa"
+vue-eslint-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz#a4ed2669f87179dedd06afdd8736acbb3a3864d6"
+  integrity sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==
   dependencies:
     debug "^4.1.1"
-    eslint-scope "^4.0.0"
-    eslint-visitor-keys "^1.0.0"
-    espree "^5.0.0"
+    eslint-scope "^5.0.0"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
     esquery "^1.0.1"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -1078,7 +1187,15 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
 
-yargs-parser@13.1.1, yargs-parser@^13.1.1:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   dependencies:
@@ -1093,7 +1210,23 @@ yargs-unparser@1.6.0:
     lodash "^4.17.15"
     yargs "^13.3.0"
 
-yargs@13.3.0, yargs@^13.3.0:
+yargs@13.3.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
+
+yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,9 +810,9 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.15.3:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
 
 progress@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Builds on #287, with updates to get builds passing.

- Breaking change: Update `engines` to new prettier Node minimum (10.13.0)
- Travis: update/simplify travis.yml according to new minimum (adding Node 12 as well)
- npm: Updated prettier peerDep. Also updated eslint peerDep. (new minimum version of Node (10.13) for prettier makes eslint 5 no longer necessary to support)
- npm: Updated available devDeps.
