### PR TITLE
Avoid clearing Prettier cache when not using prettierrc

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -152,7 +152,12 @@ module.exports = {
         const filepath = context.getFilename();
         const source = sourceCode.text;
 
-        if (prettier && prettier.clearConfigCache) {
+        // This allows long-running ESLint processes (e.g. vscode-eslint) to
+        // pick up changes to .prettierrc without restarting the editor. This
+        // will invalidate the prettier plugin cache on every file as well which
+        // will make ESLint very slow, so it would probably be a good idea to
+        // find a better way to do this.
+        if (usePrettierrc && prettier && prettier.clearConfigCache) {
           prettier.clearConfigCache();
         }
 


### PR DESCRIPTION
At Airbnb we've noticed that the Prettier ESLint rule is extraordinarily
slow. When running ESLint with `TIMING=1`, Prettier is two orders of
magnitude slower than our other slowest rules (which come from
eslint-plugin-import mostly).

I spent some time investigating this today. I ran the Chrome DevTools
profiler while running ESLint on a directory with 480 files in it.
Looking at the flame charts, I noticed that this plugin ended up calling
Prettier's pluginSearchDirs.map.pluginSearchDir for every file that was
being linted, even though it was being memoized. Through some logging, I
determined that the Prettier cache was being cleared between every file,
and narrowed it down to this line, which was added here:

  https://github.com/prettier/eslint-plugin-prettier/pull/55#discussion_r139307523

It looks like this cache busting was added to make it so long-running
ESLint processes (e.g. for vscode-eslint) would be able to pick up
changes to prettierrc files without having to reload the process.
Thankfully, we don't use a prettierrc file at Airbnb right now, in favor
of putting our Prettier config inline with our ESLint config. So the
quick performance fix for us is to simply skip the cache busting when
this option is not enabled.

In my profiling, this reduces the time spent in ESLint's verifyAndFix
when running on the same 480 files from 34 seconds to 26 seconds, for a
total savings of 8 seconds.

For folks who are using prettierrc files, this is still pretty crappy,
so it would be great to find a better way to do this. Unfortunately my
knowledge of the inner workings of vscode-eslint and ESLint are not
enough to know if there might be a better way to do this--e.g. maybe
there's some ESLint option that we can respect here?

Before:

<img width="1257" alt="DevTools - Node js 2020-06-11 12-28-38" src="https://user-images.githubusercontent.com/195534/84420199-51ffd980-abdf-11ea-8b5b-1eaeff71f577.png">

After:

<img width="1133" alt="DevTools - Node js 2020-06-11 12-31-45" src="https://user-images.githubusercontent.com/195534/84420471-af942600-abdf-11ea-8459-9285faf24aa8.png">
