### PR TITLE
New: Add option to ignore editorconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ For the list of every available exclusion rule set, please see the [readme of es
       }]
       ```
 
+    - `useEditorConfig`: Enables [resolving editorconfig](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) file options (default: `true`).
+
+      ```json
+      "prettier/prettier": ["error", {}, {
+        "useEditorConfig": false
+      }]
+      ```
+
 - The rule is autofixable -- if you run `eslint` with the `--fix` flag, your code will be formatted according to `prettier` style.
 
 ---

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -137,7 +137,8 @@ module.exports = {
                 type: 'object',
                 properties: {},
                 additionalProperties: true
-              }
+              },
+              useEditorConfig: { type: 'boolean' }
             },
             additionalProperties: true
           }
@@ -148,6 +149,8 @@ module.exports = {
           !context.options[1] || context.options[1].usePrettierrc !== false;
         const eslintFileInfoOptions =
           (context.options[1] && context.options[1].fileInfoOptions) || {};
+        const useEditorConfig =
+          !context.options[1] || context.options[1].useEditorConfig !== false;
         const sourceCode = context.getSourceCode();
         const filepath = context.getFilename();
         const source = sourceCode.text;
@@ -172,7 +175,7 @@ module.exports = {
 
             const prettierRcOptions = usePrettierrc
               ? prettier.resolveConfig.sync(filepath, {
-                  editorconfig: true
+                  editorconfig: useEditorConfig
                 })
               : null;
 


### PR DESCRIPTION
We use this plugin in our project for linting. However we had some trouble running it properly lately. 

In our use case we didn't specified `useTabs` option in the `.prettierrc` file and expected it to [default to](https://prettier.io/docs/en/options.html#tabs) `false`. But as we inspected the problem we saw some of our colleagues had `.editorconfig` files previously installed in their home directories. Since prettier resolves config files upwards to root directory the only way to prevent such a complication from within the project is preventing prettier from resolving the `.editorconfig` files. 

As prettier [supports this option](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) I believe it would be proper to add it to the plugin too. This PR introduces the mentioned option: `useEditorConfig`