### PR TITLE
Turn off problematic rules in recommended config (prepare for next eslint-config-prettier version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ This plugin ships with a `plugin:prettier/recommended` config that sets up both 
    npm install --save-dev eslint-config-prettier
    ```
 
-   Compatibility:
-
-   - eslint-plugin-prettier@>=4 ↔ eslint-config-prettier@>=7
-   - eslint-plugin-prettier@<4 ↔ eslint-config-prettier@<7
-
 2. Then you need to add `plugin:prettier/recommended` as the _last_ extension in your `.eslintrc.json`:
 
    ```json
@@ -76,8 +71,6 @@ This plugin ships with a `plugin:prettier/recommended` config that sets up both 
      "extends": ["plugin:prettier/recommended"]
    }
    ```
-
-   See [eslint-config-prettier’s explanation](https://github.com/prettier/eslint-config-prettier#eslint-plugin-prettier) for more information about what this config does.
 
    You can then set Prettier's own options inside a `.prettierrc` file.
 
@@ -88,18 +81,41 @@ This plugin ships with a `plugin:prettier/recommended` config that sets up both 
      "extends": [
        "plugin:prettier/recommended",
        "prettier/flowtype",
-       "prettier/react",
-       "prettier/standard"
+       "prettier/react"
      ]
    }
    ```
 
    For the list of every available exclusion rule set, please see the [readme of eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/master/README.md).
 
-## Known issues
+Exactly what does `plugin:prettier/recommended` do? Well, this is what it expands to:
 
-- eslint-plugin-prettier can be quite slow sometimes: [#304](https://github.com/prettier/eslint-plugin-prettier/issues/304)
-- `arrow-body-style` and `prefer-arrow-callback` autofix can conflict with `prettier/prettier` autofix: [#65](https://github.com/prettier/eslint-plugin-prettier/issues/65)
+```json
+{
+  "extends": ["prettier"],
+  "plugins": ["prettier"],
+  "rules": {
+    "prettier/prettier": "error",
+    "arrow-body-style": "off",
+    "prefer-arrow-callback": "off"
+  }
+}
+```
+
+- `"extends": ["prettier"]` enables the main config from `eslint-config-prettier`, which turns off some ESLint core rules that conflict with Prettier.
+- `"plugins": ["prettier"]` registers this plugin.
+- `"prettier/prettier": "error"` turns on the rule provided by this plugin, which runs Prettier from within ESLint.
+- `"arrow-body-style": "off"` and `"prefer-arrow-callback": "off"` turns off two ESLint core rules that unfortunately are problematic with this plugin – see the next section.
+
+## `arrow-body-style` and `prefer-arrow-callback` issue
+
+If you use [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style) or [prefer-arrow-callback](https://eslint.org/docs/rules/prefer-arrow-callback) together with the `prettier/prettier` rule from this plugin, you can in some cases end up with invalid code due to a bug in ESLint’s autofix – see [issue #65](https://github.com/prettier/eslint-plugin-prettier/issues/65).
+
+For this reason, it’s recommended to turn off these rules. The `plugin:prettier/recommended` config does that for you.
+
+You _can_ still use these rules together with this plugin if you want, because the bug does not occur _all the time._ But if you do, you need to keep in mind that you might end up with invalid code, where you manually have to insert a missing closing parenthesis to get going again.
+
+If you’re fixing large of amounts of previously unformatted code, consider temporarily disabling the `prettier/prettier` rule and running `eslint --fix` and `prettier --write` separately.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Runs [Prettier](https://github.com/prettier/prettier) as an [ESLint](http://eslint.org) rule and reports differences as individual ESLint issues.
 
+If your desired formatting does not match Prettier’s output, you should use a different tool such as [prettier-eslint](https://github.com/prettier/prettier-eslint) instead.
+
 ## Sample
 
 ```js
@@ -52,11 +54,9 @@ Then, in your `.eslintrc.json`:
 
 ## Recommended Configuration
 
-This plugin works best if you disable all other ESLint rules relating to code formatting, and only enable rules that detect patterns in the AST. (If another active ESLint rule disagrees with `prettier` about how code should be formatted, it will be impossible to avoid lint errors.) You can use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to disable all formatting-related ESLint rules.
+This plugin works best if you disable all other ESLint rules relating to code formatting, and only enable rules that detect potential bugs. (If another active ESLint rule disagrees with `prettier` about how code should be formatted, it will be impossible to avoid lint errors.) You can use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to disable all formatting-related ESLint rules.
 
-If your desired formatting does not match the `prettier` output, you should use a different tool such as [prettier-eslint](https://github.com/prettier/prettier-eslint) instead.
-
-To integrate this plugin with `eslint-config-prettier`, you can use the `"recommended"` configuration:
+This plugin ships with a `plugin:prettier/recommended` config that sets up both the plugin and `eslint-config-prettier` in one go.
 
 1. In addition to the above installation instructions, install `eslint-config-prettier`:
 
@@ -64,7 +64,12 @@ To integrate this plugin with `eslint-config-prettier`, you can use the `"recomm
    npm install --save-dev eslint-config-prettier
    ```
 
-2. Then you need to add `plugin:prettier/recommended` as the last extension in your `.eslintrc.json`:
+   Compatibility:
+
+   - eslint-plugin-prettier@>=4 ↔ eslint-config-prettier@>=7
+   - eslint-plugin-prettier@<4 ↔ eslint-config-prettier@<7
+
+2. Then you need to add `plugin:prettier/recommended` as the _last_ extension in your `.eslintrc.json`:
 
    ```json
    {
@@ -72,28 +77,29 @@ To integrate this plugin with `eslint-config-prettier`, you can use the `"recomm
    }
    ```
 
-This does three things:
+   See [eslint-config-prettier’s explanation](https://github.com/prettier/eslint-config-prettier#eslint-plugin-prettier) for more information about what this config does.
 
-- Enables `eslint-plugin-prettier`.
-- Sets the `prettier/prettier` rule to `"error"`.
-- Extends the `eslint-config-prettier` configuration.
+   You can then set Prettier's own options inside a `.prettierrc` file.
 
-You can then set Prettier's own options inside a `.prettierrc` file.
+3. Some ESLint plugins (such as [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)) also contain rules that conflict with Prettier. Add extra exclusions for the plugins you use like so:
 
-3. In order to support special ESLint plugins (e.g. [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)), add extra exclusions for the plugins you use like so:
+   ```json
+   {
+     "extends": [
+       "plugin:prettier/recommended",
+       "prettier/flowtype",
+       "prettier/react",
+       "prettier/standard"
+     ]
+   }
+   ```
 
-```json
-{
-  "extends": [
-    "plugin:prettier/recommended",
-    "prettier/flowtype",
-    "prettier/react",
-    "prettier/standard"
-  ]
-}
-```
+   For the list of every available exclusion rule set, please see the [readme of eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/master/README.md).
 
-For the list of every available exclusion rule set, please see the [readme of eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/master/README.md).
+## Known issues
+
+- eslint-plugin-prettier can be quite slow sometimes: [#304](https://github.com/prettier/eslint-plugin-prettier/issues/304)
+- `arrow-body-style` and `prefer-arrow-callback` autofix can conflict with `prettier/prettier` autofix: [#65](https://github.com/prettier/eslint-plugin-prettier/issues/65)
 
 ## Options
 

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -107,10 +107,12 @@ function reportReplace(context, offset, deleteText, insertText) {
 module.exports = {
   configs: {
     recommended: {
-      extends: ['prettier', 'prettier/prettier'],
+      extends: ['prettier'],
       plugins: ['prettier'],
       rules: {
-        'prettier/prettier': 'error'
+        'prettier/prettier': 'error',
+        'arrow-body-style': 'off',
+        'prefer-arrow-callback': 'off'
       }
     }
   },

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -107,7 +107,7 @@ function reportReplace(context, offset, deleteText, insertText) {
 module.exports = {
   configs: {
     recommended: {
-      extends: ['prettier'],
+      extends: ['prettier', 'prettier/prettier'],
       plugins: ['prettier'],
       rules: {
         'prettier/prettier': 'error'


### PR DESCRIPTION
https://github.com/prettier/eslint-config-prettier/pull/168 is moving `arrow-body-style` and `prefer-arrow-callback` (which conflict with eslint-plugin-prettier, #65) from the `prettier` config to its own file, `prettier/prettier`. The reason for doing this is:

- We don’t want to turn off those rules for all Prettier users who _don’t_ use eslint-plugin-prettier.
- Since those exclusions are specific to eslint-plugin-prettier, it makes sense to put them in a separate file just like we do for all other plugins.

This PR turns off those two rules in the `recommended` config. This helps people upgrade:

- People can upgrade eslint-plugin-prettier but not eslint-config-prettier without any problems.
- People who upgrade both can keep using the `recommended` config without issues.

This PR also moves documentation about all of this from eslint-config-prettier to this repo.

This can and should be released before https://github.com/prettier/eslint-config-prettier/pull/168