### PR TITLE
Skip CI for eslint 6 + node 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,12 @@ jobs:
           - eslint-version: 7.x
             node-version: 6.x
           # eslint 6 does not support node 6
+          # the version of chalk used in eslint 6 does not support node 8
+          - eslint-version: 6.x
+            node-version: 8.x
           - eslint-version: 6.x
             node-version: 6.x
+
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
           - eslint-version: 6.x
             node-version: 6.x
 
-
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The version of chalk that gets installef with eslint 6 requires node 10.