### PR TITLE
Minor: Do not clear the config cache on each run

### DIFF
--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -154,15 +154,6 @@ module.exports = {
         const filepath = context.getFilename();
         const source = sourceCode.text;
 
-        // This allows long-running ESLint processes (e.g. vscode-eslint) to
-        // pick up changes to .prettierrc without restarting the editor. This
-        // will invalidate the prettier plugin cache on every file as well which
-        // will make ESLint very slow, so it would probably be a good idea to
-        // find a better way to do this.
-        if (usePrettierrc && prettier && prettier.clearConfigCache) {
-          prettier.clearConfigCache();
-        }
-
         return {
           Program() {
             if (!prettier) {


### PR DESCRIPTION
Fixes #304

This halfs the time taken on CLI runs. However when you make a config
change your editor won't pick up that change until you reload your
editor window (either by restarting your editor, or in VSCode there is a
"Reload window" command).

Given that most of the time you're not adjusting your config, this
speedup is worth that extra bit of friction.

**After this change your editor's eslint plugin will not instantly pick up config changes in `.prettierrc`.** I suggest moving your prettier config into package.json - which eslint plugins should already be watching as it may effect eslint configuration changes. Worst case scenario you'll need to restart your editor after changing your prettier configuration.

On my [test repo](https://github.com/shopify/polaris-react), getting timing info by running `TIMING=1 yarn run eslint .`: Without this change the prettier/prettier rule takes ~19s, with this change it takes ~8.5s.