### PR TITLE
fix: add eslint-config-prettier as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue-eslint-parser": "^6.0.0"
   },
   "peerDependenciesMeta": {
-    "eslint-plugin-prettier": {
+    "eslint-config-prettier": {
       "optional": true
     }
   },


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/prettier/eslint-plugin-prettier/pull/367 added a peer dependency on `eslint-plugin-prettier` instead of `eslint-config-prettier`

**How did you fix it?**

Changed the peer dependency from `eslint-plugin-prettier` to `eslint-config-prettier`