### PR TITLE
New: adds option to prioritize merging of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you’re fixing large of amounts of previously unformatted code, consider tem
     "prettier/prettier": ["error", {"singleQuote": true, "parser": "flow"}]
     ```
 
-    NB: This option will merge and override any config set with `.prettierrc` files
+    NB: This option will merge and override any config set with `.prettierrc` files (unless you specify `priorityOptions: 'prettierRc'` in the second option (see below))
 
 - The second option:
 
@@ -138,6 +138,19 @@ If you’re fixing large of amounts of previously unformatted code, consider tem
         "fileInfoOptions": {
           "withNodeModules": true
         }
+      }]
+      ```
+
+    - `priorityOptions`: An enum deciding which options should take precedence when merging. You might want to set `prettierRc` as the priority if you want to use `.prettierrc` files to override eslint settings (useful for distributing a shared eslint config).
+
+      - `prettierRc`: the `.prettierrc` file options take precedence over the eslint prettier options
+      - `eslint` (default): as stated above, eslint options will merge and override any config set with `.prettierrc` files
+
+      ```json
+      "prettier/prettier": ["error", {
+        tabWidth: 4
+      }, {
+        "priorityOptions": "prettierRc"
       }]
       ```
 

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -77,6 +77,12 @@ ruleTester.run('prettier', rule, {
     {
       code: `('');\n`,
       filename: path.join(__filename, '0_fake_virtual_name.js')
+    },
+    // Prioritize .prettierrc options, overriding specified eslint options
+    {
+      code: `var foo = { bar: 0 };\n`,
+      filename: getPrettierRcJsFilename('bracket-spacing'),
+      options: [{ bracketSpacing: false }, { priorityOptions: 'prettierRc' }]
     }
   ],
   invalid: [


### PR DESCRIPTION
Closes #416 

By creating a new option to configure the merging of prettier options, our shared eslint config package can now defer to a consuming project's `.prettierrc` file (or lack thereof).  With this option, our project can set default rules only in eslint, and each consuming project can easily extend those default rules.

Basic Example:

```js
// DRY - import options from base
const prettier = require('./.prettierrc.json');

module.exports = {
    rules: {
        'prettier/prettier': ['error', prettier, {
          priorityOptions: 'prettierRc',
        }],
    },
};
```

Now eslint has the prettier options, I've de-duped the options by simply requiring the package's prettierrc.json file, and consuming projects can install this package with two scenarios:
1. project **has** a .prettierrc file: newly installed shared eslint config defers to the local .prettierrc options and the consumer can remove the .prettierrc file, or remove unnecessary options.
2. project **does not have** a .prettierrc file: newly installed shared eslint config provides default options that differ from prettier defaults.

This makes sharing and extending much easier.  
1. **No need** to alter `.eslintrc` to override prettier settings there.
2. **No need** to have a `.prettierrc` file at all.
3. **No need** to extend using a `.prettierrc.js` file.

Any comments welcome!  Thanks!