### PR TITLE
Bump prettier to 2.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-self": "^1.2.1",
     "graphql": "^15.7.1",
     "mocha": "^6.2.3",
-    "prettier": "^2.4.1",
+    "prettier": "^2.6.2",
     "vue-eslint-parser": "^8.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The latest prettier verison treats Angular's waitForAsync like JS's native `async` operator. Having prettier and ESLint running `eslint-plugin-prettier`both trying to format a file causes a conflict.