### PR TITLE
Remove `Sponsors` and `Backers` section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,22 +173,6 @@ If you’re fixing large of amounts of previously unformatted code, consider tem
 
 ---
 
-## Sponsors
-
-| 1stG                                                                                                                               | RxTS                                                                                                                               | UnTS                                                                                                                               |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [![1stG Open Collective backers and sponsors](https://opencollective.com/1stG/organizations.svg)](https://opencollective.com/1stG) | [![RxTS Open Collective backers and sponsors](https://opencollective.com/rxts/organizations.svg)](https://opencollective.com/rxts) | [![UnTS Open Collective backers and sponsors](https://opencollective.com/unts/organizations.svg)](https://opencollective.com/unts) |
-
-[![Prettier Open Collective backers and sponsors](https://opencollective.com/prettier/organizations.svg)](https://opencollective.com/prettier)
-
-## Backers
-
-| 1stG                                                                                                                             | RxTS                                                                                                                             | UnTS                                                                                                                             |
-| -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| [![1stG Open Collective backers and sponsors](https://opencollective.com/1stG/individuals.svg)](https://opencollective.com/1stG) | [![RxTS Open Collective backers and sponsors](https://opencollective.com/rxts/individuals.svg)](https://opencollective.com/rxts) | [![UnTS Open Collective backers and sponsors](https://opencollective.com/unts/individuals.svg)](https://opencollective.com/unts) |
-
-[![Prettier Open Collective backers and sponsors](https://opencollective.com/prettier/individuals.svg)](https://opencollective.com/prettier)
-
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/prettier/eslint-plugin-prettier/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
For the fundings, I suggest you open a joined account on opencollective, but before that I guess we can use @JounQin's personal account.

But I don't think display all those unrelated orgs in README is the right thing.

