### PR TITLE
feat: introduce option to force format extracted fragements

### DIFF
--- a/.changeset/strong-lions-hang.md
+++ b/.changeset/strong-lions-hang.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": minor
+---
+
+Introduce option to force format extracted fragements

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.changeset/
 # this file doesn't exist, but we use it as a filename that should be ignored
 # by prettier in the tests
 ignore-me.js

--- a/README.md
+++ b/README.md
@@ -153,6 +153,22 @@ If you’re fixing large of amounts of previously unformatted code, consider tem
       }
       ```
 
+    - `forceFormatExtracted`: Enables formatting of extracted fragements, (default: `false`).
+      ESLint supports processors that let you extract and lint JS fragments within a non-JS language, for example using `eslint-plugin-markdown` to extract and lint a code block inside a Markdown file. Usually, you don't want to have the fragement itself formatted by Prettier as the whole file
+      might already be formatted anyway. This is why `eslint-plugin-prettier` ignores such fragements by default. However, for cases you want to have such extracted fragements formatted by Prettier you can use this option to force it.
+
+      ```json
+      {
+        "prettier/prettier": [
+          "error",
+          {},
+          {
+            "forceFormatExtracted": true
+          }
+        ]
+      }
+      ```
+
     - `fileInfoOptions`: Options that are passed to [prettier.getFileInfo](https://prettier.io/docs/en/api.html#prettiergetfileinfofilepath--options) to decide whether a file needs to be formatted. Can be used for example to opt-out from ignoring files located in `node_modules` directories.
 
       ```json

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -10,7 +10,7 @@
  * @typedef {import('eslint').AST.SourceLocation} SourceLocation
  * @typedef {import('eslint').ESLint.Plugin} Plugin
  * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean }} Options
+ * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean, forceFormatExtracted?: boolean  }} Options
  */
 
 'use strict';
@@ -107,6 +107,7 @@ const eslintPluginPrettier = {
             type: 'object',
             properties: {
               usePrettierrc: { type: 'boolean' },
+              forceFormatExtracted: { type: 'boolean' },
               fileInfoOptions: {
                 type: 'object',
                 properties: {},
@@ -125,6 +126,7 @@ const eslintPluginPrettier = {
       create(context) {
         const usePrettierrc =
           !context.options[1] || context.options[1].usePrettierrc !== false;
+        const forceFormatExtracted = !!context.options[1]?.forceFormatExtracted;
         /**
          * @type {FileInfoOptions}
          */
@@ -175,6 +177,7 @@ const eslintPluginPrettier = {
                   onDiskFilepath,
                   parserPath: context.parserPath,
                   usePrettierrc,
+                  forceFormatExtracted,
                 },
                 fileInfoOptions,
               );

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-mdx": "^2.0.2",
     "eslint-plugin-eslint-plugin": "^5.0.6",
+    "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-mdx": "^2.0.2",
     "eslint-plugin-self": "^1.2.1",
     "eslint-plugin-svelte": "^2.7.0",

--- a/test/.prettierrc
+++ b/test/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/test/fixtures/md.md
+++ b/test/fixtures/md.md
@@ -1,0 +1,4 @@
+# Example
+```js
+const example = "example"
+```

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -46,6 +46,21 @@ const eslint = new ESLint({
           'mdx/code-block': true,
         },
       },
+      // To test 'forceFormatExtracted' option
+      {
+        files: '**/*.md',
+        plugins: ['markdown'],
+        processor: 'markdown/markdown',
+        rules: {
+          'prettier/prettier': 'off',
+        },
+      },
+      {
+        files: '**/*.md/*.js',
+        rules: {
+          'prettier/prettier': ['error', {}, { forceFormatExtracted: true }],
+        },
+      },
       {
         files: '**/eslint-plugin-svelte3/*.svelte',
         plugins: ['svelte3'],
@@ -254,6 +269,28 @@ runFixture('*.mdx', [
       line: 6,
       message: 'Insert `;`',
       messageId: 'insert',
+      nodeType: null,
+      ruleId: 'prettier/prettier',
+      severity: 2,
+    },
+  ],
+]);
+
+// Testing 'forceFormatExtracted' option
+// (should only format code block, not the whole file)
+runFixture('*.md', [
+  [
+    {
+      column: 17,
+      endColumn: 26,
+      endLine: 3,
+      fix: {
+        range: [32, 41],
+        text: "'example';",
+      },
+      line: 3,
+      message: 'Replace `"example"` with `\'example\';`',
+      messageId: 'replace',
       nodeType: null,
       ruleId: 'prettier/prettier',
       severity: 2,

--- a/worker.js
+++ b/worker.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean }} Options
+ * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean, forceFormatExtracted?: boolean }} Options
  */
 
 const { runAsWorker } = require('synckit');
@@ -26,6 +26,7 @@ runAsWorker(
       onDiskFilepath,
       parserPath,
       usePrettierrc,
+      forceFormatExtracted,
       ...eslintPrettierOptions
     },
     eslintFileInfoOptions,
@@ -124,7 +125,7 @@ runAsWorker(
       if (inferParserToBabel) {
         initialOptions.parser = 'babel';
       }
-    } else {
+    } else if (!forceFormatExtracted) {
       // Similar to https://github.com/prettier/stylelint-prettier/pull/22
       // In all of the following cases ESLint extracts a part of a file to
       // be formatted and there exists a prettier parser for the whole file.


### PR DESCRIPTION
The default behavior skipping the formatting of extracted fragments (e.g. code blocks in Markdown files, parsed via `eslint-plugin-markdown`) is usually fine. https://github.com/prettier/eslint-plugin-prettier/blob/00449dfd152dbdd5a0a52426bb538dddcf702328/worker.js#L127-L150

However, there are cases where you want to have such fragments formatted anyways.
This pull request introduces the new option `forceFormatExtracted` (happy to change the naming) which turns this particular check off.