### PR TITLE
fix: compatibility with prettier@3 without plugins

### DIFF
--- a/.changeset/stale-guests-battle.md
+++ b/.changeset/stale-guests-battle.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+fix: compatibility with prettier@3 without plugins

--- a/worker.js
+++ b/worker.js
@@ -48,7 +48,7 @@ runAsWorker(
         withNodeModules: false,
         ignorePath: '.prettierignore',
         plugins: /** @type {string[] | undefined} */ (
-          prettierRcOptions ? prettierRcOptions.plugins : null
+          prettierRcOptions ? prettierRcOptions.plugins : undefined
         ),
         ...eslintFileInfoOptions,
       },


### PR DESCRIPTION
Fixes https://github.com/prettier/eslint-plugin-prettier/issues/563

In `prettier@3.0.0` the behavior of plugins list default value was changed

from this:

https://github.com/prettier/prettier/blob/e154250e19caa6d1b23bb1e7803ee5f8d0f95445/src/common/load-plugins.js#L25-L27

to this:

https://github.com/prettier/prettier/blob/266344398c1c90f7dc7b206ba8077cecc294470f/src/main/plugins/load-plugins.js#L3

So `plugins: null` causes runtime error, the default value should be `undefined` as declared [there](https://github.com/prettier/prettier/blob/266344398c1c90f7dc7b206ba8077cecc294470f/src/index.d.ts#L784)