### PR TITLE
fix: `parserPath` type might be `undefined` on Eslint Flat Config

### DIFF
--- a/.changeset/thick-birds-share.md
+++ b/.changeset/thick-birds-share.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+fix: `parserPath` type might be `undefined` on Eslint Falt Config

--- a/worker.js
+++ b/worker.js
@@ -112,7 +112,10 @@ runAsWorker(
         // it could be processed by `@ota-meshi/eslint-plugin-svelte`, `eslint-plugin-svelte` or `eslint-plugin-svelte3`
         case 'svelte': {
           // The `source` would be modified by `eslint-plugin-svelte3`
-          if (typeof parserPath === "string" && !parserPath.includes('svelte-eslint-parser')) {
+          if (
+            typeof parserPath === 'string' &&
+            !parserPath.includes('svelte-eslint-parser')
+          ) {
             // We do not support `eslint-plugin-svelte3`,
             // the users should run `prettier` on `.svelte` files manually
             return;

--- a/worker.js
+++ b/worker.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean }} Options
+ * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath?: string, usePrettierrc?: boolean }} Options
  */
 
 const { runAsWorker } = require('synckit');
@@ -112,7 +112,7 @@ runAsWorker(
         // it could be processed by `@ota-meshi/eslint-plugin-svelte`, `eslint-plugin-svelte` or `eslint-plugin-svelte3`
         case 'svelte': {
           // The `source` would be modified by `eslint-plugin-svelte3`
-          if (!parserPath.includes('svelte-eslint-parser')) {
+          if (typeof parserPath === "string" && !parserPath.includes('svelte-eslint-parser')) {
             // We do not support `eslint-plugin-svelte3`,
             // the users should run `prettier` on `.svelte` files manually
             return;


### PR DESCRIPTION
Fix this issue #584

to compatibility with Eslint Flat Config.
`parserPath` might be `undefined` and will throw error on worker. so check parserPath is string type before usage.

Maybe we can remove whole `svelte` block since [`eslint-plugin-svelte3`](https://github.com/sveltejs/eslint-plugin-svelte3) is deprecated