### PR TITLE
fix: specify eslint-config-prettier as peer dependency

### DIFF
--- a/.changeset/mean-trees-judge.md
+++ b/.changeset/mean-trees-judge.md
@@ -1,0 +1,7 @@
+---
+'eslint-plugin-prettier': patch
+---
+
+fix: specify `eslint-config-prettier` as peer dependency
+
+It's already added to `peerDependenciesMeta` as optional, which means it should also be specified in `peerDependencies`.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "peerDependencies": {
     "@types/eslint": ">=8.0.0",
     "eslint": ">=8.0.0",
+    "eslint-config-prettier": "*",
     "prettier": ">=3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
In preparation for https://github.com/prettier/eslint-plugin-prettier/pull/592, to avoid adding this unrelated change to the PR that introduces flat config support.