### PR TITLE
feat: support parsing `markdown` via `eslint-mdx` natively

### DIFF
--- a/.changeset/slimy-boats-fold.md
+++ b/.changeset/slimy-boats-fold.md
@@ -1,5 +1,5 @@
 ---
-'eslint-plugin-prettier': patch
+"eslint-plugin-prettier": patch
 ---
 
 Add exports mapping to package.json, to allow `import eslintPluginRecommended from 'eslint-plugin-prettier/recommended'` to work as expected.

--- a/.changeset/warm-cougars-attack.md
+++ b/.changeset/warm-cougars-attack.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+feat: support parsing `markdown` via `eslint-mdx` natively

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
   "arrowParens": "avoid",
   "singleQuote": true,
-  "plugins": ["@prettier/plugin-pug", "prettier-plugin-pkg"]
+  "plugins": ["@prettier/plugin-pug", "prettier-plugin-pkg"],
+  "overrides": [
+    {
+      "files": ".changeset/**/*",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -9,8 +9,10 @@
  * @typedef {import('eslint').AST.Range} Range
  * @typedef {import('eslint').AST.SourceLocation} SourceLocation
  * @typedef {import('eslint').ESLint.Plugin} Plugin
+ * @typedef {import('eslint').ESLint.ObjectMetaProperties} ObjectMetaProperties
  * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserPath: string, usePrettierrc?: boolean }} Options
+ * @typedef {import('prettier').Options} PrettierOptions
+ * @typedef {PrettierOptions & { onDiskFilepath: string, parserMeta?: ObjectMetaProperties['meta'], parserPath?: string, usePrettierrc?: boolean }} Options
  */
 
 'use strict';
@@ -167,9 +169,11 @@ const eslintPluginPrettier = {
             }
 
             /**
-             * @type {{}}
+             * @type {PrettierOptions}
              */
             const eslintPrettierOptions = context.options[0] || {};
+
+            const parser = context.languageOptions?.parser;
 
             // prettier.format() may throw a SyntaxError if it cannot parse the
             // source code it is given. Usually for JS files this isn't a
@@ -190,6 +194,12 @@ const eslintPluginPrettier = {
                   ...eslintPrettierOptions,
                   filepath,
                   onDiskFilepath,
+                  parserMeta:
+                    parser &&
+                    (parser.meta ?? {
+                      name: parser.name,
+                      version: parser.version,
+                    }),
                   parserPath: context.parserPath,
                   usePrettierrc,
                 },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,14 +25,6 @@ module.exports = [
       'eslint-plugin/report-message-format': ['error', '^[^a-z].*\\.$'],
     },
   },
-  {
-    files: ['**/*.md'],
-    rules: { 'prettier/prettier': ['error', { parser: 'markdown' }] },
-  },
-  {
-    files: ['**/*.mdx'],
-    rules: { 'prettier/prettier': ['error', { parser: 'mdx' }] },
-  },
   // Global ignores
   // If a config block only contains an `ignores` key, then the globs are
   // ignored globally

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "@graphql-eslint/eslint-plugin@3.20.0": "patches/@graphql-eslint__eslint-plugin@3.20.0.patch"
+      "@graphql-eslint/eslint-plugin@3.20.0": "patches/@graphql-eslint__eslint-plugin@3.20.0.patch",
+      "@types/eslint@8.44.7": "patches/@types__eslint@8.44.7.patch"
     }
   }
 }

--- a/patches/@types__eslint@8.44.7.patch
+++ b/patches/@types__eslint@8.44.7.patch
@@ -1,0 +1,14 @@
+diff --git a/index.d.ts b/index.d.ts
+index 75ae420e38148c632230763f26382ef0d9024427..6b8b08da2e25b54dedf41f1db0f2ba6e2c718b30 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -753,6 +753,9 @@ export namespace Rule {
+         id: string;
+         options: any[];
+         settings: { [name: string]: any };
++        languageOptions: {
++            parser: Linter.ParserModule;
++        } & Linter.ParserOptions;
+         parserPath: string;
+         parserOptions: Linter.ParserOptions;
+         parserServices: SourceCode.ParserServices;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@graphql-eslint/eslint-plugin@3.20.0':
     hash: e3c7i33vtfs4mivhjwqctijsoe
     path: patches/@graphql-eslint__eslint-plugin@3.20.0.patch
+  '@types/eslint@8.44.7':
+    hash: r7mjcwcmok5lsw2nb63qlph4sa
+    path: patches/@types__eslint@8.44.7.patch
 
 dependencies:
   prettier-linter-helpers:
@@ -44,7 +47,7 @@ devDependencies:
     version: 3.0.0(prettier@3.0.0)
   '@types/eslint':
     specifier: ^8.44.7
-    version: 8.44.7
+    version: 8.44.7(patch_hash=r7mjcwcmok5lsw2nb63qlph4sa)
   '@types/prettier-linter-helpers':
     specifier: ^1.0.1
     version: 1.0.4
@@ -1216,12 +1219,13 @@ packages:
       '@types/ms': 0.7.31
     dev: true
 
-  /@types/eslint@8.44.7:
+  /@types/eslint@8.44.7(patch_hash=r7mjcwcmok5lsw2nb63qlph4sa):
     resolution: {integrity: sha512-f5ORu2hcBbKei97U73mf+l9t4zTGl74IqZ0GQk4oVea/VS8tQZYkUveSYojk+frraAVYId0V2WC9O4PTNru2FQ==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
     dev: true
+    patched: true
 
   /@types/estree-jsx@1.0.0:
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}

--- a/test/fixtures/md.md
+++ b/test/fixtures/md.md
@@ -1,0 +1,5 @@
+# Heading
+
+```ts
+export declare const x = 1
+```

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -38,7 +38,7 @@ const eslint = new ESLint({
     extends: 'plugin:prettier/recommended',
     overrides: [
       {
-        files: '*.mdx',
+        files: ['*.{md,mdx}'],
         extends: 'plugin:mdx/recommended',
         settings: {
           'mdx/code-block': true,
@@ -227,6 +227,26 @@ mdxRuleTester.run('eslint-plugin-mdx', rule, {
     }),
   ],
 });
+
+runFixture('*.md', [
+  [
+    {
+      column: 27,
+      endColumn: 27,
+      endLine: 4,
+      fix: {
+        range: [43, 43],
+        text: ';',
+      },
+      line: 4,
+      message: 'Insert `;`',
+      messageId: 'insert',
+      nodeType: null,
+      ruleId: 'prettier/prettier',
+      severity: 2,
+    },
+  ],
+]);
 
 runFixture('*.mdx', [
   [


### PR DESCRIPTION
The following is unnecessary anymore when using with `eslint-mdx`/`eslint-plugin-mdx`!

```json5
[
  {
    files: ["**/*.md"],
    rules: { "prettier/prettier": ["error", { parser: "markdown" }] },
  },
  {
    files: ["**/*.mdx"],
    rules: { "prettier/prettier": ["error", { parser: "mdx" }] },
  },
]
```