### PR TITLE
fix: add package.json exports field

### DIFF
--- a/.changeset/slimy-boats-fold.md
+++ b/.changeset/slimy-boats-fold.md
@@ -1,0 +1,7 @@
+---
+'eslint-plugin-prettier': patch
+---
+
+Add exports mapping to package.json, to allow `import eslintPluginRecommended from 'eslint-plugin-prettier/recommended'` to work as expected.
+
+Strictly speaking this is a breaking change as it removes the ability for people to import from "eslint-plugin-prettier/eslint-plugin-prettier.js" and "eslint-plugin-prettier/recommended.js" but the former was never recommended in the first place and the latter has only been available for a few days.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
     "node": "^14.18.0 || >=16.0.0"
   },
   "main": "eslint-plugin-prettier.js",
+  "exports": {
+    ".": {
+      "types": "./eslint-plugin-prettier.d.ts",
+      "default": "./eslint-plugin-prettier.js"
+    },
+    "./recommended": {
+      "types": "./recommended.d.ts",
+      "default": "./recommended.js"
+    }
+  },
   "types": "eslint-plugin-prettier.d.ts",
   "files": [
     "eslint-plugin-prettier.d.ts",


### PR DESCRIPTION
Fix #622.

Add exports mapping to package.json, to allow `import eslintPluginRecommended from 'eslint-plugin-prettier/recommended'` to work as expected.

Strictly speaking this is a breaking change as it removes the ability for people to import from "eslint-plugin-prettier/eslint-plugin-prettier.js" and "eslint-plugin-prettier/recommended.js" but the former was never a good idea in the first place and the latter has only been available for a few days, so I'm not worried about closing off those two import paths in a non-major release.