### PR TITLE
chore: add `package.json` into `exports` map

### DIFF
--- a/.changeset/rich-pigs-allow.md
+++ b/.changeset/rich-pigs-allow.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+chore: add `package.json` into `exports` map

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "./recommended": {
       "types": "./recommended.d.ts",
       "default": "./recommended.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "eslint-plugin-prettier.d.ts",
   "files": [


### PR DESCRIPTION
It's very common to read the `package.json`, this is not a required but nice-to-have entry.