### PR TITLE
export `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       "types": "./eslint-plugin-prettier.d.ts",
       "default": "./eslint-plugin-prettier.js"
     },
+    "./package.json": "./package.json",
     "./recommended": {
       "types": "./recommended.d.ts",
       "default": "./recommended.js"


### PR DESCRIPTION
I have a use case wherein I'm reading `eslint-plugin-prettier/package.json`'s dependency versions as a part of a unit test.

Currently, this results in the error `Missing "./package.json" specifier in "eslint-plugin-prettier" package` since `package.json` is not exported. This PR addresses this, making it possible to read the package metadata.