### PR TITLE
build(deps): Bump synckit from 0.8.6 to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "prettier-linter-helpers": "^1.0.0",
-    "synckit": "^0.8.6"
+    "synckit": "^0.9.1"
   },
   "devDependencies": {
     "@1stg/remark-preset": "^2.0.0",


### PR DESCRIPTION
fixed issue in vscode-eslint: https://github.com/microsoft/vscode-eslint/issues/1856