### PR TITLE
feat(types): prefer `Config` over `FlatConfig` when they're equal

### DIFF
--- a/.changeset/lucky-badgers-judge.md
+++ b/.changeset/lucky-badgers-judge.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": minor
+---
+
+feat(types): prefer `Config` over `FlatConfig` when they're equal

--- a/recommended.d.ts
+++ b/recommended.d.ts
@@ -1,5 +1,12 @@
 import { Linter } from 'eslint';
 
-declare const recommendedConfig: Linter.FlatConfig;
+// prettier-ignore
+type IfEqual<A, B, X = A, Y = B> =
+  (<G>() => G extends A & G | G ? 1 : 2) extends
+  (<G>() => G extends B & G | G ? 1 : 2)
+    ? X
+    : Y;
+
+declare const recommendedConfig: IfEqual<Linter.Config, Linter.FlatConfig>;
 
 export = recommendedConfig;


### PR DESCRIPTION
Hello,

the type `FlatConfig` has been replaced with `Config`, according to the deprecation warning.
![image](https://github.com/user-attachments/assets/8480e754-3ee3-4c9d-901a-4ce708cc7ccc)


I just changed the type with the suggested one.

Cheers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  - Improved type system to prefer the `Config` type over `FlatConfig` when both are equivalent in the configuration.  
- **Documentation**  
  - Added a changeset documenting the minor update to the configuration types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->