### PR TITLE
Support 'config' Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.3.0
+
+### Minor Changes
+
+- [#689](https://github.com/prettier/eslint-plugin-prettier/pull/689) [`acbcc76`](https://github.com/prettier/eslint-plugin-prettier/commit/acbcc76) From [@colinta](https://github.com/colinta)! - fix: support 'config' Option
+
 ## 5.2.1
 
 ### Patch Changes

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -114,6 +114,7 @@ const eslintPluginPrettier = {
             type: 'object',
             properties: {
               usePrettierrc: { type: 'boolean' },
+              config: { type: 'string' },
               fileInfoOptions: {
                 type: 'object',
                 properties: {},
@@ -137,6 +138,7 @@ const eslintPluginPrettier = {
          */
         const fileInfoOptions =
           (context.options[1] && context.options[1].fileInfoOptions) || {};
+        const config = context.options?.[1]?.config;
 
         // `context.getSourceCode()` was deprecated in ESLint v8.40.0 and replaced
         // with the `sourceCode` property.
@@ -202,6 +204,7 @@ const eslintPluginPrettier = {
                     }),
                   parserPath: context.parserPath,
                   usePrettierrc,
+                  config,
                 },
                 fileInfoOptions,
               );

--- a/worker.js
+++ b/worker.js
@@ -3,7 +3,7 @@
 /**
  * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
  * @typedef {import('eslint').ESLint.ObjectMetaProperties} ObjectMetaProperties
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserMeta?: ObjectMetaProperties['meta'], parserPath?: string, usePrettierrc?: boolean }} Options
+ * @typedef {import('prettier').Options & { onDiskFilepath: string, parserMeta?: ObjectMetaProperties['meta'], parserPath?: string, usePrettierrc?: boolean, config?: string }} Options
  */
 
 const { runAsWorker } = require('synckit');
@@ -28,6 +28,7 @@ runAsWorker(
       parserMeta,
       parserPath,
       usePrettierrc,
+      config,
       ...eslintPrettierOptions
     },
     eslintFileInfoOptions,
@@ -39,6 +40,7 @@ runAsWorker(
     const prettierRcOptions = usePrettierrc
       ? await prettier.resolveConfig(onDiskFilepath, {
           editorconfig: true,
+          config,
         })
       : null;
 


### PR DESCRIPTION
Allows users to assign a custom path for the prettier config, ie a shared config in a monorepo.

Our use case is that we have a shared prettier config, but it doesn't live at the repository root.

Prettier supports this on the CLI using `--config` (and `--ignorePath`). This PR brings that feature to the eslint plugin.

e.g.
```bash
prettier --ignore-path config/prettier/prettierignore --config config/prettier/prettier.config.js --write src
```

Update: added a changelog w/ minor version bump.