### PR TITLE
chore: add name to recommended config preset

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ module.exports = [
   // eslint-community/eslint-comments does not expose a reusable flat config,
   // so create one from its legacy config
   {
+    name: '@eslint-community/eslint-comments',
     plugins: {
       '@eslint-community/eslint-comments': eslintPluginEslintComments,
     },
@@ -21,6 +22,7 @@ module.exports = [
   eslintPluginMdx.flatCodeBlocks,
   eslintPluginPrettierRecommended,
   {
+    name: 'eslint-plugin overrides',
     rules: {
       'eslint-plugin/report-message-format': ['error', '^[^a-z].*\\.$'],
     },
@@ -29,6 +31,7 @@ module.exports = [
   // If a config block only contains an `ignores` key, then the globs are
   // ignored globally
   {
+    name: 'global ignores',
     ignores: [
       'CHANGELOG.md',
       '.github/ISSUE_TEMPLATE.md',

--- a/recommended.js
+++ b/recommended.js
@@ -4,6 +4,7 @@ const eslintPluginPrettier = require('./eslint-plugin-prettier');
 // Merge the contents of eslint-config-prettier into every
 module.exports = {
   ...eslintConfigPrettier,
+  name: 'prettier/recommended',
   plugins: {
     ...eslintConfigPrettier.plugins,
     prettier: eslintPluginPrettier,


### PR DESCRIPTION
This PR adds a name to the eslint config preset.

The name will be shown in when inspecting the eslint config and for debugging purposes.

You can view the eslint preview using the following command:

````sh
npx @eslint/config-inspector@latest
````

<details>
<summary>UI-Diff</summary>

| Before | After |
| --- | --- |
| ![grafik](https://github.com/user-attachments/assets/594dba01-67be-4926-bea9-53d247d19a80) | ![{4B409241-20BA-411B-86C4-352989EA3FF0}](https://github.com/user-attachments/assets/292f6662-278d-419e-acb5-a3e71769cfcf) |

The remaining anonymous sections are from other eslint-plugin presets that don't have a name yet.

</details>

I also added the config group names to the eslint config itself for consistency.
I can revert that part if you don't like it.