### PR TITLE
chore: fix badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-plugin-prettier [![Build Status](https://github.com/prettier/eslint-plugin-prettier/workflows/CI/badge.svg?branch=master)](https://github.com/prettier/eslint-plugin-prettier/actions?query=workflow%3ACI+branch%3Amaster)
+# eslint-plugin-prettier [![Build Status](https://github.com/prettier/eslint-plugin-prettier/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/prettier/eslint-plugin-prettier/actions?query=workflow%3ACI+branch%3Amaster)
 
 Runs [Prettier](https://github.com/prettier/prettier) as an [ESLint](https://eslint.org) rule and reports differences as individual ESLint issues.
 


### PR DESCRIPTION
Let's also rename `master` to `main`? 

I can take care, leave a thumbup if you agree @JounQin @BPScott

- Update CI and settings.
- Update changeset config.
- Check related settings.

Should be all.