### PR TITLE
chore: migrate `@typedef`jsdoc to `@import`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,7 @@
   "singleQuote": true,
   "plugins": [
     "@prettier/plugin-pug",
+    "prettier-plugin-jsdoc",
     "prettier-plugin-pkg",
     "prettier-plugin-svelte"
   ],

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lint-staged": "^15.5.0",
     "mocha": "^11.1.0",
     "prettier": "^3.5.3",
+    "prettier-plugin-jsdoc": "^1.3.2",
     "prettier-plugin-pkg": "^0.19.0",
     "prettier-plugin-svelte": "^3.3.3",
     "simple-git-hooks": "^2.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ specifiers:
   mocha: ^11.1.0
   prettier: ^3.5.3
   prettier-linter-helpers: ^1.0.0
+  prettier-plugin-jsdoc: ^1.3.2
   prettier-plugin-pkg: ^0.19.0
   prettier-plugin-svelte: ^3.3.3
   simple-git-hooks: ^2.12.1
@@ -72,6 +73,7 @@ devDependencies:
   lint-staged: 15.5.0
   mocha: 11.1.0
   prettier: 3.5.3
+  prettier-plugin-jsdoc: 1.3.2_prettier@3.5.3
   prettier-plugin-pkg: 0.19.0_prettier@3.5.3
   prettier-plugin-svelte: 3.3.3_2ymjksukde6plevbhihn5hqk44
   simple-git-hooks: 2.12.1
@@ -1576,6 +1578,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /binary-searching/2.0.5:
+    resolution: {integrity: sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==}
+    dev: true
+
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -1776,6 +1782,11 @@ packages:
   /commander/13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+    dev: true
+
+  /comment-parser/1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
     dev: true
 
   /compare-func/2.0.0:
@@ -4375,6 +4386,20 @@ packages:
     dependencies:
       fast-diff: 1.3.0
     dev: false
+
+  /prettier-plugin-jsdoc/1.3.2_prettier@3.5.3:
+    resolution: {integrity: sha512-LNi9eq0TjyZn/PUNf/SYQxxUvGg5FLK4alEbi3i/S+2JbMyTu790c/puFueXzx09KP44oWCJ+TaHRyM/a0rKJQ==}
+    engines: {node: '>=14.13.1 || >=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.0
+    dependencies:
+      binary-searching: 2.0.5
+      comment-parser: 1.4.1
+      mdast-util-from-markdown: 2.0.2
+      prettier: 3.5.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /prettier-plugin-pkg/0.19.0_prettier@3.5.3:
     resolution: {integrity: sha512-wlBvVhAZQ+iOH8/4gWc1SxJbf5++xwKmnFkqHYUsmoQIg6hgdyL1055Z9FOWa6cumqL/QwqdOzY9aH4McdjKyw==}

--- a/test/prettier.mjs
+++ b/test/prettier.mjs
@@ -291,9 +291,7 @@ runFixture('*.mdx', [
   ],
 ]);
 
-/**
- * @see https://github.com/sveltejs/svelte/blob/226bf419f9b9b5f1a6da33bd6403dd70afe58b52/packages/svelte/package.json#L73
- */
+/** @see https://github.com/sveltejs/svelte/blob/226bf419f9b9b5f1a6da33bd6403dd70afe58b52/packages/svelte/package.json#L73 */
 const svelteUnsupported = +process.versions.node.split('.')[0] < 16;
 
 runFixture(
@@ -387,10 +385,10 @@ runFixture('invalid-prettierrc/*', [
 // ------------------------------------------------------------------------------
 
 /**
- * Reads a fixture file and returns an "invalid" case for use by RuleTester.
- * The fixture format aims to reduce the pain of debugging offsets by keeping
- * the lines and columns of the test code as close to what the rule will report
- * as possible.
+ * Reads a fixture file and returns an "invalid" case for use by RuleTester. The
+ * fixture format aims to reduce the pain of debugging offsets by keeping the
+ * lines and columns of the test code as close to what the rule will report as
+ * possible.
  *
  * @param {string} name - Fixture basename.
  * @returns {object} A {code, output, options, errors} test object.
@@ -421,7 +419,8 @@ function loadInvalidFixture(name) {
 }
 
 /**
- * Builds a dummy javascript file path to trick prettier into resolving a specific .prettierrc file.
+ * Builds a dummy javascript file path to trick prettier into resolving a
+ * specific .prettierrc file.
  *
  * @param {string} dir - Prettierrc fixture basename.
  * @param {string} file
@@ -433,14 +432,18 @@ function getPrettierRcJsFilename(dir, file = 'dummy.js') {
   );
 }
 
+/**
+ * @type {ESLint}
+ * @import {ESLint} from 'eslint'
+ */
 let eslint;
 
 /**
- *
  * @param {string} pattern
- * @param {import('eslint').Linter.LintMessage[][]} asserts
+ * @param {Linter.LintMessage[][]} asserts
  * @param {boolean} [skip]
  * @returns {Promise<void>}
+ * @import {Linter} from 'eslint'
  */
 async function runFixture(pattern, asserts, skip) {
   if (!eslint) {

--- a/worker.js
+++ b/worker.js
@@ -1,15 +1,21 @@
 // @ts-check
 
 /**
- * @typedef {import('prettier').FileInfoOptions} FileInfoOptions
- * @typedef {import('eslint').ESLint.ObjectMetaProperties} ObjectMetaProperties
- * @typedef {import('prettier').Options & { onDiskFilepath: string, parserMeta?: ObjectMetaProperties['meta'], parserPath?: string, usePrettierrc?: boolean }} Options
+ * @typedef {PrettierOptions & {
+ *   onDiskFilepath: string;
+ *   parserMeta?: ESLint.ObjectMetaProperties['meta'];
+ *   parserPath?: string;
+ *   usePrettierrc?: boolean;
+ * }} Options
+ * @import {FileInfoOptions, Options as PrettierOptions} from 'prettier'
+ * @import {ESLint} from 'eslint'
  */
 
 const { runAsWorker } = require('synckit');
 
 /**
- * @type {typeof import('prettier')}
+ * @type {typeof Prettier}
+ * @import * as Prettier from 'prettier'
  */
 let prettier;
 
@@ -176,9 +182,7 @@ runAsWorker(
       }
     }
 
-    /**
-     * @type {import('prettier').Options}
-     */
+    /** @type {PrettierOptions} */
     const prettierOptions = {
       ...initialOptions,
       ...prettierRcOptions,


### PR DESCRIPTION
### Summary

This PR migrates the JSDoc `@typedef` declarations to `@import` syntax in:
- `worker.js`
- `eslint-plugin-prettier.js`

close #728

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates JSDoc `@typedef` to `@import` syntax in `worker.js` and `eslint-plugin-prettier.js`, centralizing types in `types.d.ts` and fixing formatting issues.
> 
>   - **Type Definitions**:
>     - Migrated JSDoc `@typedef` to `@import` syntax in `worker.js` and `eslint-plugin-prettier.js`.
>     - Centralized type definitions in `types.d.ts`.
>   - **Formatting**:
>     - Fixed Prettier formatting issues in `worker.js` and `eslint-plugin-prettier.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for 18973d62c5d01de847b764bbba240f29b4ecbbe2. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added Prettier plugins for JSDoc formatting and type annotations to the configuration and development dependencies.
  - Updated type annotations and imports for improved type safety and compatibility with newer ESLint APIs.
- **Style**
  - Reformatted and condensed JSDoc comments for improved readability in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->