### PR TITLE
ci: enable autofix.ci and pkg-pr-new workflows

### DIFF
--- a/.changeset/wise-houses-build.md
+++ b/.changeset/wise-houses-build.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+ci: enable `NPM_CONFIG_PROVENANCE` env

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,22 +1,18 @@
-name: Release
+name: autofix.ci # For security reasons, the workflow in which the autofix.ci action is used must be named "autofix.ci".
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
-
 jobs:
-  release:
-    name: Release
+  autofix:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -34,14 +30,10 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --prefer-frozen-lockfile
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
+      - name: Format Codes
+        run: pnpm format
+
+      - name: Apply autofix.ci
+        uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944 # v1.3.1
         with:
-          publish: pnpm release
-          commit: 'chore: release eslint-plugin-prettier'
-          title: 'chore: release eslint-plugin-prettier'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,13 @@ jobs:
             eslint: 8
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - name: Use Node.js ${{ matrix.node }}
+      - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,23 +1,16 @@
-name: Release
-
+name: Publish Any Commit
 on:
-  push:
-    branches:
-      - main
+  - push
+  - pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
-
 jobs:
-  release:
-    name: Release
+  publish:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,14 +27,5 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --prefer-frozen-lockfile
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release
-          commit: 'chore: release eslint-plugin-prettier'
-          title: 'chore: release eslint-plugin-prettier'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish
+        run: pnpm dlx pkg-pr-new publish --compact

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/prettier/eslint-plugin-prettier.git",
   "homepage": "https://github.com/prettier/eslint-plugin-prettier#readme",
   "author": "Teddy Katz",
-  "contributors": [
-    "JounQin (https://github.com/JounQin) <admin@1stg.me>"
+  "maintainers": [
+    "JounQin <admin@1stg.me> (https://github.com/JounQin)"
   ],
   "funding": "https://opencollective.com/eslint-plugin-prettier",
   "license": "MIT",


### PR DESCRIPTION
`NPM_CONFIG_PROVENANCE` env is enabled for releasing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new GitHub workflows for autofix and commit publishing, update existing workflows, and modify `package.json` maintainers field.
> 
>   - **Workflows**:
>     - Add `autofix.yml` for automatic code formatting on pull requests.
>     - Add `pkg-pr-new.yml` for publishing any commit on push or pull request.
>     - Update `ci.yml` to include named steps for better clarity.
>     - Update `release.yml` to include concurrency settings and permissions, and set `NPM_CONFIG_PROVENANCE` to true.
>   - **Package.json**:
>     - Change `contributors` field to `maintainers`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for a54d7feb1e7ea078f1ed00962f736abe2e003983. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added new GitHub Actions workflows for automated code formatting and publishing.
  - Improved CI and release workflows with clearer step names, enhanced concurrency controls, and updated permissions.
  - Enabled npm package provenance metadata in the release process.
  - Updated package metadata to use a "maintainers" field instead of "contributors".
  - Added documentation for a patch update to a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->