### PR TITLE
reactor: migrate `worker.js` to `worker.mjs`

### DIFF
--- a/.changeset/eight-hornets-approve.md
+++ b/.changeset/eight-hornets-approve.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": minor
+---
+
+refactor: migrate `worker.js` to `worker.mjs`

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -172,7 +172,7 @@ const eslintPluginPrettier = {
             if (!prettierFormat) {
               // Prettier is expensive to load, so only load it if needed.
               prettierFormat = /** @type {PrettierFormat} */ (
-                require('synckit').createSyncFn(require.resolve('./worker'))
+                require('synckit').createSyncFn(require.resolve('./worker.mjs'))
               );
             }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-prettier.js",
     "recommended.d.ts",
     "recommended.js",
-    "worker.js"
+    "worker.mjs"
   ],
   "keywords": [
     "eslint",

--- a/worker.mjs
+++ b/worker.mjs
@@ -11,7 +11,7 @@
  * @import {ESLint} from 'eslint'
  */
 
-const { runAsWorker } = require('synckit');
+import { runAsWorker } from 'synckit';
 
 /**
  * @type {typeof Prettier}

--- a/worker.mjs
+++ b/worker.mjs
@@ -12,12 +12,7 @@
  */
 
 import { runAsWorker } from 'synckit';
-
-/**
- * @type {typeof Prettier}
- * @import * as Prettier from 'prettier'
- */
-let prettier;
+import prettier from 'prettier';
 
 runAsWorker(
   /**
@@ -38,10 +33,6 @@ runAsWorker(
     },
     eslintFileInfoOptions,
   ) => {
-    if (!prettier) {
-      prettier = await import('prettier');
-    }
-
     const prettierRcOptions = usePrettierrc
       ? await prettier.resolveConfig(onDiskFilepath, {
           editorconfig: true,

--- a/worker.mjs
+++ b/worker.mjs
@@ -11,8 +11,8 @@
  * @import {ESLint} from 'eslint'
  */
 
-import { runAsWorker } from 'synckit';
 import prettier from 'prettier';
+import { runAsWorker } from 'synckit';
 
 runAsWorker(
   /**


### PR DESCRIPTION
This PR changes `worker.js` to `worker.mjs`

close #732 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed `worker.js` to `worker.mjs` and updated import/export syntax to ECMAScript module format.
> 
>   - **File Renaming**:
>     - Rename `worker.js` to `worker.mjs`.
>   - **Import/Export Changes**:
>     - Change `require` to `import` for `runAsWorker` in `worker.mjs`.
>   - **Configuration Updates**:
>     - Update `require.resolve('./worker')` to `require.resolve('./worker.mjs')` in `eslint-plugin-prettier.js`.
>     - Update `package.json` to include `worker.mjs` instead of `worker.js` in the `files` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for 4e8ef1fe5386c03afc2ef191060fee142cd03873. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated internal module format from CommonJS (.js) to ES module (.mjs) for improved compatibility.
	- Adjusted package contents to include the updated worker file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->