### PR TITLE
fix(deps): bump `synckit` to v0.11.7

### DIFF
--- a/.changeset/new-crabs-glow.md
+++ b/.changeset/new-crabs-glow.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+fix(deps): bump `synckit` to v0.11.7 to fix potential `TypeError: Cannot read properties of undefined (reading 'message')` error

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "prettier-linter-helpers": "^1.0.0",
-    "synckit": "^0.11.0"
+    "synckit": "^0.11.7"
   },
   "devDependencies": {
     "@1stg/remark-preset": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,12 +40,12 @@ specifiers:
   prettier-plugin-svelte: ^3.3.3
   simple-git-hooks: ^2.12.1
   svelte: ^5.25.3
-  synckit: ^0.11.0
+  synckit: ^0.11.7
   vue-eslint-parser: ^10.1.1
 
 dependencies:
   prettier-linter-helpers: 1.0.0
-  synckit: 0.11.1
+  synckit: 0.11.7
 
 devDependencies:
   '@1stg/remark-preset': 3.0.1_prettier@3.5.3
@@ -1273,8 +1273,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: true
 
-  /@pkgr/core/0.2.0:
-    resolution: {integrity: sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==}
+  /@pkgr/core/0.2.4:
+    resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dev: false
 
@@ -5619,12 +5619,11 @@ packages:
       whatwg-mimetype: 4.0.0
     dev: true
 
-  /synckit/0.11.1:
-    resolution: {integrity: sha512-fWZqNBZNNFp/7mTUy1fSsydhKsAKJ+u90Nk7kOK5Gcq9vObaqLBLjWFDBkyVU9Vvc6Y71VbOevMuGhqv02bT+Q==}
+  /synckit/0.11.7:
+    resolution: {integrity: sha512-/5aUeiRPqmY0CRTJ+iVWfOOMHWTDh8JAIuNF1A6nZ2/RdCNWwKaUrO5Qw5ephLK6dYa7NclYBI0ahdgUECvdhA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
-      '@pkgr/core': 0.2.0
-      tslib: 2.8.1
+      '@pkgr/core': 0.2.4
     dev: false
 
   /synckit/0.9.2:
@@ -5695,6 +5694,7 @@ packages:
 
   /tslib/2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    dev: true
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
close #671
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `synckit` dependency to version `^0.11.7` in `package.json`.
> 
>   - **Dependencies**:
>     - Bump `synckit` version from `^0.11.0` to `^0.11.7` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for 33c9c4628b99f2f818938b9c983cf17d9210d400. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated a dependency to resolve a potential runtime error, improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->