### PR TITLE
fix: add 'oxc', 'oxc-ts' and 'hermes' parsers to parserBlocklist

### DIFF
--- a/.changeset/five-boats-decide.md
+++ b/.changeset/five-boats-decide.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prettier": patch
+---
+
+fix: add 'oxc', 'oxc-ts' and 'hermes' parsers to `parserBlocklist`

--- a/worker.mjs
+++ b/worker.mjs
@@ -165,6 +165,9 @@ runAsWorker(
         'angular',
         'svelte',
         'pug',
+        'oxc',
+        'oxc-ts',
+        'hermes',
       ];
       if (parserBlocklist.includes(/** @type {string} */ (inferredParser))) {
         return;


### PR DESCRIPTION
Fixes #754
No tests were added as I could not find any related to other parsers in `parserBlocklist`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'oxc', 'oxc-ts', and 'hermes' to `parserBlocklist` in `worker.mjs` to prevent their use in formatting.
> 
>   - **Behavior**:
>     - Adds 'oxc', 'oxc-ts', and 'hermes' to `parserBlocklist` in `worker.mjs` to prevent their use in formatting.
>   - **Testing**:
>     - No tests added due to absence of existing tests for `parserBlocklist`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for fff72392d0b9c17e673da49a67b641ae9b2bb805. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting behavior by preventing formatting on file fragments parsed by 'oxc', 'oxc-ts', and 'hermes' parsers in certain scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->