### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           node-version: lts/*
           cache: pnpm
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Install Dependencies
         run: pnpm install --prefer-frozen-lockfile
 
@@ -43,5 +46,4 @@ jobs:
           title: 'chore: release eslint-plugin-prettier'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ''


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers

related https://github.com/e18e/ecosystem-issues/issues/201
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable trusted publishing in GitHub Actions by updating npm and modifying environment variables in `release.yml`.
> 
>   - **CI/CD**:
>     - Updates `.github/workflows/release.yml` to enable trusted publishing with npm.
>     - Adds step to upgrade npm to the latest version.
>     - Removes `NPM_CONFIG_PROVENANCE` and sets `NPM_TOKEN` to an empty string in the environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Feslint-plugin-prettier&utm_source=github&utm_medium=referral)<sup> for 8e10ea7adddca385f80c9a05768bae060c3562e2. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now upgrades npm to the latest version before installing dependencies, improving consistency in build environments.
  * Updated publish step environment configuration by removing provenance settings and secret-based token usage for that step.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->