### PR TITLE
feat: support standard flat file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,18 @@ This will:
 
 ## Configuration (new: `eslint.config.js`)
 
-For [flat configuration](https://eslint.org/docs/latest/use/configure/configuration-files-new), this plugin ships with an `eslint-plugin-prettier/recommended` config that sets up both `eslint-plugin-prettier` and [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) in one go.
+For [flat configuration](https://eslint.org/docs/latest/use/configure/configuration-files-new), this plugin ships with a `recommended` config that sets up both `eslint-plugin-prettier` and [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) in one go.
 
-Import `eslint-plugin-prettier/recommended` and add it as the _last_ item in the configuration array in your `eslint.config.js` file so that `eslint-config-prettier` has the opportunity to override other configs:
+Import `eslint-plugin-prettier` and use `...prettier.configs.recommended` as the _last_ item in your `defineConfig` so that `eslint-config-prettier` has the opportunity to override other configs:
 
 ```js
-const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
+import prettier from 'eslint-plugin-prettier';
+import { defineConfig } from 'eslint/config';
 
-module.exports = [
+export default defineConfig(
   // Any other config imports go at the top
-  eslintPluginPrettierRecommended,
-];
+  ...prettier.configs.recommended,
+);
 ```
 
 This will:

--- a/eslint-plugin-prettier.d.ts
+++ b/eslint-plugin-prettier.d.ts
@@ -1,5 +1,11 @@
 import { ESLint } from 'eslint';
 
-declare const eslintPluginPrettier: ESLint.Plugin;
+declare const eslintPluginPrettier: ESLint.Plugin & {
+  configs: {
+    recommended: import('eslint').Linter.Config<
+      import('eslint').Linter.RulesRecord
+    >[];
+  };
+};
 
 export = eslintPluginPrettier;

--- a/eslint-plugin-prettier.js
+++ b/eslint-plugin-prettier.js
@@ -131,15 +131,21 @@ function reportDifference(context, difference) {
 const eslintPluginPrettier = {
   meta: { name, version },
   configs: {
-    recommended: {
-      extends: ['prettier'],
-      plugins: ['prettier'],
-      rules: {
-        'prettier/prettier': 'error',
-        'arrow-body-style': 'off',
-        'prefer-arrow-callback': 'off',
+    recommended: [
+      {
+        name: 'prettier/recommended',
+        plugins: {
+          get prettier() {
+            return eslintPluginPrettier;
+          },
+        },
+        rules: {
+          'prettier/prettier': 'error',
+          'arrow-body-style': 'off',
+          'prefer-arrow-callback': 'off',
+        },
       },
-    },
+    ],
   },
   rules: {
     prettier: {


### PR DESCRIPTION
## Changes

- feat: Adds support for standard flat file format.

## Issues

- fixes https://github.com/prettier/eslint-plugin-prettier/issues/764

### Notes

- This PR is similar to https://github.com/prettier/eslint-plugin-prettier/pull/759 but does not add a new rule, it simply extends the existing code to support the standard flat-file format as well.
- I tested both the current implementation and the standard implementation and they both still work.
- I understand your comment about not having 2 ways to do things but I think we should recommend this method moving forward as it is consistent with every other plugin. The old method can be deprecated at some point much later or never.